### PR TITLE
refactor: change to length.out arg in seq, tidy description and && where applicable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,21 +1,36 @@
 Package: tf
-Title: S3 classes and methods for tidy functional data 
+Title: S3 classes and methods for tidy functional data
 Version: 0.1.0
-Authors@R: c(person("Fabian", "Scheipl", email = "fabian.scheipl@googlemail.com", role = c("aut", "cre")), person("Jeff", "Goldsmith", role = c("aut")), person("Julia", "Wrobel", role = c("aut")))
-Description: Provides S3 classes and methods for representing, visualizing and wrangling tidy functional data.
-Depends: R (>= 4.1)
-Imports:
-  checkmate, methods, mgcv, mvtnorm, pracma, purrr, refund, rlang, stats, vctrs (>= 0.2.4), zoo
+Authors@R: c(
+    person("Fabian", "Scheipl", , "fabian.scheipl@googlemail.com", role = c("aut", "cre")),
+    person("Jeff", "Goldsmith", role = "aut"),
+    person("Julia", "Wrobel", role = "aut")
+  )
+Description: Provides S3 classes and methods for representing, visualizing
+    and wrangling tidy functional data.
 License: MIT + file LICENSE
-Encoding: UTF-8
-LazyData: true
-RoxygenNote: 7.2.2
+URL: https://tidyfun.github.io/tf/
+Depends: 
+    R (>= 4.1)
+Imports:
+    checkmate,
+    methods,
+    mgcv,
+    mvtnorm,
+    pracma,
+    purrr,
+    refund,
+    rlang,
+    stats,
+    vctrs (>= 0.2.4),
+    zoo
 Suggests: 
+    covr,
     data.table,
     dplyr,
     fda,
-    janitor,
     gridExtra,
+    janitor,
     knitr,
     maps,
     rmarkdown,
@@ -23,9 +38,13 @@ Suggests:
     SemiPar,
     testthat,
     tidyverse,
-    viridisLite,
-    covr
+    viridisLite
+VignetteBuilder: 
+    knitr
+Encoding: UTF-8
+LazyData: true
 Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3
 Collate:
     'approx.R'
     'brackets.R'
@@ -56,5 +75,3 @@ Collate:
     'vctrs.R'
     'where.R'
     'zoom.R'
-VignetteBuilder: knitr
-URL: https://tidyfun.github.io/tf/

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -60,7 +60,7 @@
 #' # save them as a functional data vector again, use `tfd` or `tfb` instead:
 #' tfd(x, arg = seq(0, 10, by = .01), resolution = 1e-3)
 `[.tf` <- function(x, i, j, interpolate = TRUE, matrix = TRUE) {
-  if (!interpolate & inherits(x, "tfb")) {
+  if (!interpolate && inherits(x, "tfb")) {
     interpolate <- TRUE
     message("interpolate argument ignored for data in basis representation")
   }
@@ -88,7 +88,7 @@
   if (missing(j)) {
     return(x)
   }
-  if (matrix & is.list(j)) {
+  if (matrix && is.list(j)) {
     stop("need a single vector-valued <j> if matrix = TRUE")
   }
   j <- ensure_list(j)
@@ -148,7 +148,7 @@
     all(tf_domain(x) == tf_domain(value)),
     length(value) %in% c(1, length(i))
   )
-  if (inherits(x, "tfd_reg") | inherits(x, "tfb")) {
+  if (inherits(x, "tfd_reg") || inherits(x, "tfb")) {
     assert_true(identical(tf_arg(x), tf_arg(value)))
   }
   if (is_tfd(x)) {

--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -33,7 +33,7 @@ df_2_mat <- function(data, binning = FALSE, maxbins = 1000) {
   if (binning && (length(bins) > maxbins)) {
     binvalues <- seq((1 - 0.001 * sign(bins[1])) * bins[1],
                      (1 + 0.001 * sign(bins[length(bins)])) * bins[length(bins)],
-                     l = maxbins + 1
+                     length.out = maxbins + 1
     )
     bins <- binvalues
     binvalues <- head(stats::filter(binvalues, c(0.5, 0.5)), -1)

--- a/R/convert.R
+++ b/R/convert.R
@@ -18,7 +18,7 @@
 as.data.frame.tf <- function(x, row.names = NULL, optional = FALSE, unnest = FALSE, ...) {
   if (unnest) return(tf_2_df(x))
   colname <- deparse(substitute(x))
-  ret <- data.frame(tmp = 1:length(x), row.names = row.names)
+  ret <- data.frame(tmp = seq_along(x), row.names = row.names)
   ret[[colname]] <- x
   ret[, colname, drop = FALSE]
 }

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -14,12 +14,12 @@
 #' @export
 #' @family tidyfun inter/extrapolation functions
 #' @examples 
-#' f <- tf_rgp(3, arg = seq(0, 1, l = 11))
+#' f <- tf_rgp(3, arg = seq(0, 1, length.out = 11))
 #' tf_evaluate(f) |> str()
 #' tf_evaluate(f, arg = .5) |> str()
 #' # equivalent, as matrix:
 #' f[, .5]
-#' new_grid <- seq(0, 1, l = 6)
+#' new_grid <- seq(0, 1, length.out = 6)
 #' tf_evaluate(f, arg = new_grid) |> str()
 #' # equivalent, as matrix:
 #' f[, new_grid]

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -10,7 +10,7 @@ prep_plotting_arg <- function(f, n_grid) {
   if (!isTRUE(n_grid > 1)) {
     tf_arg(f)
   } else {
-    seq(tf_domain(f)[1], tf_domain(f)[2], length = n_grid) |>
+    seq(tf_domain(f)[1], tf_domain(f)[2], length.out = n_grid) |>
       round_resolution(attr(f, "resolution")) |>
       setdiff(
         round_resolution(unlist(tf_arg(f)), attr(f, "resolution"))

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -23,19 +23,19 @@
 #' @export
 #' @examples
 #' # thinning out a densely observed tfd
-#' (dense <- tf_rgp(10, arg = seq(0, 1, l = 1001)))
-#' (less_dense <- tf_interpolate(dense, arg = seq(0, 1, l = 101)))
+#' (dense <- tf_rgp(10, arg = seq(0, 1, length.out = 1001)))
+#' (less_dense <- tf_interpolate(dense, arg = seq(0, 1, length.out = 101)))
 #'
 #' # filling out sparse data (use a suitable evaluator -function!)
-#' sparse <- tf_rgp(10, arg = seq(0, 5, l = 21))
+#' sparse <- tf_rgp(10, arg = seq(0, 5, length.out = 21))
 #' plot(sparse)
 #' tfd(sparse, evaluator= tf_approx_spline) |>   #change eval. for better interpolation
-#'   tf_interpolate(arg = seq(0, 5, l = 201)) |>
+#'   tf_interpolate(arg = seq(0, 5, length.out = 201)) |>
 #'   lines(col = 2)
 #'
 #' set.seed(1860)
 #' (sparse_irregular <- tf_rgp(5) |>  tf_sparsify(.5) |> tf_jiggle())
-#' tf_interpolate(sparse_irregular, arg = seq(0, 1, l = 51))
+#' tf_interpolate(sparse_irregular, arg = seq(0, 1, length.out = 51))
 #' 
 tf_interpolate <- function(object, arg, ...) UseMethod("tf_interpolate")
 

--- a/R/math.R
+++ b/R/math.R
@@ -30,8 +30,8 @@ summarize_tf <- function(..., op = NULL, eval = FALSE) {
   )
   if (eval) {
     ret <- do.call(tfd, c(args, evaluator = attr(funs, "evaluator_name")))
-    if (is_irreg(funs) & !is_irreg(ret)) ret <- as.tfd_irreg(ret)
-    if (!is_irreg(funs) & is_irreg(ret)) ret <- as.tfd(ret)
+    if (is_irreg(funs) && !is_irreg(ret)) ret <- as.tfd_irreg(ret)
+    if (!is_irreg(funs) && is_irreg(ret)) ret <- as.tfd(ret)
     return(ret)
   } else {
     return(do.call(tfb, c(args,

--- a/R/ops.R
+++ b/R/ops.R
@@ -172,7 +172,7 @@ Ops.tfb <- function(e1, e2) {
       }
       stopifnot(all(compare_tf_attribs(e1, e2)))
     }
-    if (both_funs & .Generic %in% c("+", "-")) {
+    if (both_funs && .Generic %in% c("+", "-")) {
       # just add/subtract coefs for identical bases
       return(fun_op(e1, e2, .Generic))
     } else {

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -60,7 +60,7 @@ print.tfd_reg <- function(x, n = 10, ...) {
   cat(" based on", length(tf_arg(x)), "evaluations each\n")
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   if (length(x)) {
-    cat(format(x[1:min(n, length(x))], ...), sep = "\n")
+    cat(format(x[seq_along(min(n, length(x)))], ...), sep = "\n")
     if (n < length(x)) {
       cat(paste0("    [....]   (", length(x) - n, " not shown)\n"))
     }
@@ -80,7 +80,7 @@ print.tfd_irreg <- function(x, n = 10, ...) {
   ))
   cat("inter-/extrapolation by", attr(x, "evaluator_name"), "\n")
   if (length(x)) {
-    cat(format(x[1:min(n, length(x))], ...), sep = "\n")
+    cat(format(x[seq_along(min(n, length(x)))], ...), sep = "\n")
     if (n < length(x)) {
       cat(paste0("    [....]   (", length(x) - n, " not shown)\n"))
     }
@@ -94,7 +94,7 @@ print.tfb <- function(x, n = 10, ...) {
   NextMethod()
   cat(" in basis representation:\n using ", attr(x, "basis_label"), "\n")
   if (length(x)) {
-    cat(format(x[1:min(n, length(x))], ...), sep = "\n")
+    cat(format(x[seq_along(min(n, length(x)))], ...), sep = "\n")
     if (n < length(x)) {
       cat(paste0("    [....]   (", length(x) - n, " not shown)\n"))
     }

--- a/R/rng.R
+++ b/R/rng.R
@@ -51,7 +51,7 @@ tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"),
   
   if (length(arg) == 1) {
     assert_integerish(arg, lower = 1)
-    arg <- seq(0, 1, length = arg)
+    arg <- seq(0, 1, length.out = arg)
   } 
   assert_numeric(arg, any.missing = FALSE, unique = TRUE)
   assert_number(n, lower = 1)

--- a/R/tfb-spline-utils.R
+++ b/R/tfb-spline-utils.R
@@ -89,12 +89,12 @@ fit_unpenalized_ls <- function(data, spec_object, arg_u, regular) {
 fit_penalized <- function(data, spec_object, gam_args, arg_u, regular, global, 
                           ls_fit) { 
   
-  if (global & gam_args$sp == -1) {
+  if (global && gam_args$sp == -1) {
     # find a suitable global level of smoothing based on a pilot estimate
     # uses 10% of curves, at most 100, at least 5
     # uses median of the smothing parameters on this pilot sample.
     pilot_id <- round(seq(from = 1, to = nlevels(data$id), 
-                    length = max(1, 
+                    length.out = max(1, 
                                  min(max(5, 0.1 * nlevels(data$id)), 100))))
     pilot_id <- levels(data$id)[unique(pilot_id)]
     arg_u_pilot <- arg_u

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -78,7 +78,7 @@ new_tfb_spline <- function(data, domain = numeric(), arg = numeric(),
       fit_penalized(data = data, spec_object = spec_object, arg_u = arg_u,
                     gam_args = gam_args, regular = regular, global = global,
                     ls_fit = ls_fit)
-    if (global & verbose) {
+    if (global && verbose) {
       message(
         sprintf(
           c("Using global smoothing parameter sp = %.3g,",

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -231,23 +231,23 @@ tfd.list <- function(data, arg = NULL, domain = NULL,
 #' @examples
 #' #turn irregular to regular tfd by evaluating on a common grid:
 #'
-#' (f <- c(tf_rgp(1, arg = seq(0,1,l=11)), tf_rgp(1, arg = seq(0,1,l=21))))
-#' tfd(f, arg = seq(0, 1, l = 21))
+#' (f <- c(tf_rgp(1, arg = seq(0, 1, length.out = 11)), tf_rgp(1, arg = seq(0, 1, length.out = 21))))
+#' tfd(f, arg = seq(0, 1, length.out = 21))
 #' 
 #' set.seed(1213)
-#' (f <- tf_rgp(3, arg = seq(0, 1, l= 51)) |> tf_sparsify(.9))
+#' (f <- tf_rgp(3, arg = seq(0, 1, length.out = 51)) |> tf_sparsify(.9))
 #' #does not yield regular data because linear extrapolation yields NAs outside observed range:
-#' tfd(f, arg = seq(0, 1, l = 101)) 
+#' tfd(f, arg = seq(0, 1, length.out = 101)) 
 #' # this "works" (but may not yield sensible values..!!) for e.g. constant extrapolation:
-#' tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, l = 101))
+#' tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, length.out = 101))
 #' plot(f, col = 2)
-#' lines(tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, l = 151)))
+#' lines(tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, length.out = 151)))
 #' @rdname tfd
 tfd.tf <- function(data, arg = NULL, domain = NULL,
                    evaluator = NULL, resolution = NULL, ...) {
   
   evaluator_name <- enexpr(evaluator)
-  evaluator <- if (is_tfd(data) & is.null(evaluator)) {
+  evaluator <- if (is_tfd(data) && is.null(evaluator)) {
     attr(data, "evaluator_name")
   } else {
     if (is.null(evaluator)) "tf_approx_linear" else quo_name(evaluator_name)

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -60,8 +60,8 @@ vec_cast.tfd_reg.tfd_irreg <- function(x, to, ...) {
 #' @export
 vec_cast.tfd_irreg.tfd_reg <- function(x, to, ...) { 
   
-  args = attr(x, "arg")
-  cast_x = tfd(map(.x = vctrs::vec_data(x), ~data.frame(arg = args, value = .x)))
+  args <- attr(x, "arg")
+  cast_x <- tfd(map(.x = vctrs::vec_data(x), ~data.frame(arg = args, value = .x)))
   as.tfd_irreg.tfd_reg(cast_x)
   
 }
@@ -123,7 +123,7 @@ vec_ptype2.tfd_irreg.tfd_irreg <- function(x, y, ...) {vec_ptype2_tfd_tfd(x, y, 
 #' @name vctrs
 #' @family tidyfun vctrs
 #' @export
-vec_ptype2_tfd_tfd = function(x, y, ...) {
+vec_ptype2_tfd_tfd <- function(x, y, ...) {
   
   funs <- list(x, y)
   compatible <- do.call(rbind, map(
@@ -134,11 +134,11 @@ vec_ptype2_tfd_tfd = function(x, y, ...) {
   stopifnot(all(compatible[, "domain"]))
   make_irreg <- rep(FALSE, length(funs))
   irreg <- map_lgl(funs, is_irreg)
-  if (!any(irreg) & !all(compatible[, "arg"])) {
+  if (!any(irreg) && !all(compatible[, "arg"])) {
     warning("concatenating functions on different grids.")
     make_irreg <- rep(TRUE, length(funs))
   }
-  if (any(irreg) & !all(irreg)) {
+  if (any(irreg) && !all(irreg)) {
     warning("concatenating functions on different grids.")
     make_irreg[!irreg] <- TRUE
   }
@@ -205,7 +205,7 @@ vec_cast.tfb_fpc <- function(x, to, ...) UseMethod("vec_cast.tfb_fpc")
 #' @method vec_cast.tfb_spline tfb_spline
 #' @export
 vec_cast.tfb_spline.tfb_spline <- function(x, to, ...) { 
-  attributes_to = flatten(list(list(x), 
+  attributes_to <- flatten(list(list(x), 
                         arg = list(tf_arg(to)),
                         attr(to, "basis_args")))
   do.call(tfb, attributes_to)
@@ -286,7 +286,7 @@ vec_ptype2.tfb_fpc.tfb_fpc <- function(x, y, ...) {vec_ptype2_tfb_tfb(x, y, ...)
 #' @name vctrs
 #' @family tidyfun vctrs
 #' @export
-vec_ptype2_tfb_tfb = function(x, y, ...) {
+vec_ptype2_tfb_tfb <- function(x, y, ...) {
   funs <- list(x, y)
   compatible <- do.call(rbind, map(
     funs,

--- a/R/where.R
+++ b/R/where.R
@@ -29,7 +29,7 @@
 #'  - `return = "range"`: a data frame with columns "begin" and "end".
 #'  - else, a numeric vector of the same length as `f` with `NA` for entries of `f` that nowhere fulfill the `cond`ition.
 #' @examples
-#'   lin <- 1:4 * tfd(seq(-1, 1,l = 11), seq(-1, 1, l = 11))
+#'   lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
 #'   tf_where(lin, value %inr% c(-1, .5))
 #'   tf_where(lin, value %inr% c(-1, .5), "range")
 #'   a <- 1

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -18,7 +18,7 @@
 #'   plot(x)
 #'   tf_zoom(x, .5, .9)
 #'   lines(tf_zoom(x, .5, .9), col = "red")
-#'   points(tf_zoom(x, seq(0, .5, l = 10), seq(.5, 1, l = 10)), col = "blue")
+#'   points(tf_zoom(x, seq(0, .5, length.out = 10), seq(.5, 1, length.out = 10)), col = "blue")
 tf_zoom <- function(f, begin, end, ...) {
   UseMethod("tf_zoom")
 }

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -52,7 +52,7 @@ tf_zoom.tfd <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2],
     list(f[, tf_arg(f), matrix = FALSE], args$begin, args$end),
     ~ subset(..1, arg >= ..2 & arg <= ..3)
   )
-  if (is_irreg(f) | !args$regular) {
+  if (is_irreg(f) || !args$regular) {
     nas <- map_lgl(ret, ~length(.x$arg) == 0)
     if (all(nas)) stop("no data in zoom region.")
     if (any(nas)) warning("NAs created by tf_zoom.")

--- a/man/tf_evaluate.Rd
+++ b/man/tf_evaluate.Rd
@@ -35,12 +35,12 @@ Also used internally by the \code{[}-operator for \code{tf} data (see \code{?tfb
 evaluate \code{object}, see examples.
 }
 \examples{
-f <- tf_rgp(3, arg = seq(0, 1, l = 11))
+f <- tf_rgp(3, arg = seq(0, 1, length.out = 11))
 tf_evaluate(f) |> str()
 tf_evaluate(f, arg = .5) |> str()
 # equivalent, as matrix:
 f[, .5]
-new_grid <- seq(0, 1, l = 6)
+new_grid <- seq(0, 1, length.out = 6)
 tf_evaluate(f, arg = new_grid) |> str()
 # equivalent, as matrix:
 f[, new_grid]

--- a/man/tf_interpolate.Rd
+++ b/man/tf_interpolate.Rd
@@ -41,19 +41,19 @@ approaches in most cases.}
 }
 \examples{
 # thinning out a densely observed tfd
-(dense <- tf_rgp(10, arg = seq(0, 1, l = 1001)))
-(less_dense <- tf_interpolate(dense, arg = seq(0, 1, l = 101)))
+(dense <- tf_rgp(10, arg = seq(0, 1, length.out = 1001)))
+(less_dense <- tf_interpolate(dense, arg = seq(0, 1, length.out = 101)))
 
 # filling out sparse data (use a suitable evaluator -function!)
-sparse <- tf_rgp(10, arg = seq(0, 5, l = 21))
+sparse <- tf_rgp(10, arg = seq(0, 5, length.out = 21))
 plot(sparse)
 tfd(sparse, evaluator= tf_approx_spline) |>   #change eval. for better interpolation
-  tf_interpolate(arg = seq(0, 5, l = 201)) |>
+  tf_interpolate(arg = seq(0, 5, length.out = 201)) |>
   lines(col = 2)
 
 set.seed(1860)
 (sparse_irregular <- tf_rgp(5) |>  tf_sparsify(.5) |> tf_jiggle())
-tf_interpolate(sparse_irregular, arg = seq(0, 1, l = 51))
+tf_interpolate(sparse_irregular, arg = seq(0, 1, length.out = 51))
 
 }
 \seealso{

--- a/man/tf_where.Rd
+++ b/man/tf_where.Rd
@@ -49,7 +49,7 @@ of the usual \code{dplyr} tricks are available as well, see examples.\cr
 Any \code{cond}ition evaluates to \code{NA} on \code{NA}-entries in \code{f}.
 }
 \examples{
-  lin <- 1:4 * tfd(seq(-1, 1,l = 11), seq(-1, 1, l = 11))
+  lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
   tf_where(lin, value \%inr\% c(-1, .5))
   tf_where(lin, value \%inr\% c(-1, .5), "range")
   a <- 1

--- a/man/tf_zoom.Rd
+++ b/man/tf_zoom.Rd
@@ -39,7 +39,7 @@ These are used to redefine or restrict the \code{domain} of \code{tf} objects.
   plot(x)
   tf_zoom(x, .5, .9)
   lines(tf_zoom(x, .5, .9), col = "red")
-  points(tf_zoom(x, seq(0, .5, l = 10), seq(.5, 1, l = 10)), col = "blue")
+  points(tf_zoom(x, seq(0, .5, length.out = 10), seq(.5, 1, length.out = 10)), col = "blue")
 }
 \seealso{
 Other tidyfun utility functions: 

--- a/man/tfd.Rd
+++ b/man/tfd.Rd
@@ -144,16 +144,16 @@ In code: \verb{resolution = 10^(floor(log10(min(diff(<arg>))) - 1)}
 \examples{
 #turn irregular to regular tfd by evaluating on a common grid:
 
-(f <- c(tf_rgp(1, arg = seq(0,1,l=11)), tf_rgp(1, arg = seq(0,1,l=21))))
-tfd(f, arg = seq(0, 1, l = 21))
+(f <- c(tf_rgp(1, arg = seq(0, 1, length.out = 11)), tf_rgp(1, arg = seq(0, 1, length.out = 21))))
+tfd(f, arg = seq(0, 1, length.out = 21))
 
 set.seed(1213)
-(f <- tf_rgp(3, arg = seq(0, 1, l= 51)) |> tf_sparsify(.9))
+(f <- tf_rgp(3, arg = seq(0, 1, length.out = 51)) |> tf_sparsify(.9))
 #does not yield regular data because linear extrapolation yields NAs outside observed range:
-tfd(f, arg = seq(0, 1, l = 101)) 
+tfd(f, arg = seq(0, 1, length.out = 101)) 
 # this "works" (but may not yield sensible values..!!) for e.g. constant extrapolation:
-tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, l = 101))
+tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, length.out = 101))
 plot(f, col = 2)
-lines(tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, l = 151)))
+lines(tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, length.out = 151)))
 }
 \concept{tfd-class}

--- a/tests/testthat/test-calculus.R
+++ b/tests/testthat/test-calculus.R
@@ -5,8 +5,8 @@ g <- 201
 from <- -3.5
 to <- 3.5
 domain <- c(from, to)
-grid <- seq(from, to, l = g)
-dgrid <- seq(from + 0.5, to - 0.5, l = 50)
+grid <- seq(from, to, length.out = g)
+dgrid <- seq(from + 0.5, to - 0.5, length.out = 50)
 
 eval_irreg <- function(expression, g, domain) {
   args <- unique(round(sort(runif(g, domain[1], domain[2])), 3))
@@ -23,7 +23,7 @@ square_irreg <- eval_irreg(expression(3 * x^2), g, domain)
 square_b <- tfb(square, k = 45, bs = "tp", verbose = FALSE)
 
 test_that("basic derivatives work", {
-  dgrid <- seq(from + 0.5, to - 0.5, l = 50)
+  dgrid <- seq(from + 0.5, to - 0.5, length.out = 50)
 
   expect_equivalent(tf_derive(cubic)[, dgrid], square[, dgrid], tolerance = .1)
   expect_equivalent(tf_derive(cubic_irreg)[, dgrid], square[, dgrid], tolerance = .1)
@@ -68,7 +68,7 @@ test_that("deriv & tf_integrate are reversible (approximately)", {
     "previously"
   )
 
-  f_pc <- tfb_fpc(f[1:3, seq(tf_domain(f)[1], tf_domain(f)[2], l = 101)],
+  f_pc <- tfb_fpc(f[1:3, seq(tf_domain(f)[1], tf_domain(f)[2], length.out = 101)],
     smooth = FALSE, verbose = FALSE
   )
   f_pc2 <- tf_integrate(tf_derive(f_pc), definite = FALSE)

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -1,6 +1,6 @@
 context("depth works")
 
-grid <- round(seq(0, 10, l = 11), 3)
+grid <- round(seq(0, 10, length.out = 11), 3)
 lin <- -3:3 * tfd(.1 * grid, grid)
 parallel <- -3:3 + tfd(0 * grid, grid)
 

--- a/tests/testthat/test-evaluator.R
+++ b/tests/testthat/test-evaluator.R
@@ -1,13 +1,13 @@
 context("evaluate")
 
-grid <- round(seq(0, 1, l = 21), 3)
+grid <- round(seq(0, 1, length.out = 21), 3)
 lin <- 2 * grid
 curve <- sin(3 * pi * grid)
 
 f_lin <- tfd(data.frame(1, grid, lin))
 f_curve <- tfd(data.frame(1, grid, curve))
 
-new_grid <- round(seq(0, 1, l = 41), 3)
+new_grid <- round(seq(0, 1, length.out = 41), 3)
 
 test_that("argval checking works", {
   expect_error(tf_evaluate(f_lin, min(grid) - 1), ">=")

--- a/tests/testthat/test-tfb-fpc.R
+++ b/tests/testthat/test-tfb-fpc.R
@@ -17,7 +17,7 @@ test_that("fpc_wsvd works for smooth equidistant data", {
   # check orthonormality for equidistant:
   fpc_smoo <- tfd(t(fpc_smoo$efunctions), arg = attr(smoo_matrix, "arg"))
   expect_true(
-    cross2(1:length(fpc_smoo),1:length(fpc_smoo)) %>% 
+    cross2(seq_along(fpc_smoo),seq_along(fpc_smoo)) %>% 
     map_lgl(~ 
           tf_integrate(fpc_smoo[.x[[1]]] * fpc_smoo[.x[[2]]]) %>% 
           round(digits = 4) %>% 
@@ -34,7 +34,7 @@ test_that("fpc_wsvd works for smooth non-equidistant data", {
   # check orthonormality for non-equidistant:
   fpc_smoo <- tfd(t(fpc_smoo$efunctions), arg = smoo_arg)
   expect_true(
-    cross2(1:length(fpc_smoo),1:length(fpc_smoo)) %>% 
+    cross2(seq_along(fpc_smoo), seq_along(fpc_smoo)) %>% 
       map_lgl(~ 
                 tf_integrate(fpc_smoo[.x[[1]]] * fpc_smoo[.x[[2]]]) %>% 
                 round(digits = 4) %>% 

--- a/tests/testthat/test-vctrs.R
+++ b/tests/testthat/test-vctrs.R
@@ -1,7 +1,7 @@
 context("vctrs")
 
-x <- tf_rgp(2, arg = seq(0, 1, l = 11))
-y <- tf_rgp(2, arg = seq(0, 1, l = 21))
+x <- tf_rgp(2, arg = seq(0, 1, length.out = 11))
+y <- tf_rgp(2, arg = seq(0, 1, length.out = 21))
 x_irr <- tf_jiggle(x) 
 
 test_that("concatenation behaves for tfd", {
@@ -16,7 +16,7 @@ test_that("concatenation behaves for tfd", {
 
 tfb_k10 = x %>% tfb(k = 10)
 tfb_k20 = x_irr %>% tfb(k = 20)
-z = tf_rgp(10, arg = seq(0, 1, l = 11)) %>% tfb_fpc()
+z = tf_rgp(10, arg = seq(0, 1, length.out = 11)) %>% tfb_fpc()
 z2 = z %>% tfb_fpc(npc = 10)
 
 test_that("concatenation behaves for tfb", {

--- a/tests/testthat/test-vctrs.R
+++ b/tests/testthat/test-vctrs.R
@@ -2,7 +2,7 @@ context("vctrs")
 
 x <- tf_rgp(2, arg = seq(0, 1, length.out = 11))
 y <- tf_rgp(2, arg = seq(0, 1, length.out = 21))
-x_irr <- tf_jiggle(x) 
+x_irr <- tf_jiggle(x)
 
 test_that("concatenation behaves for tfd", {
   expect_warning(c(x, y), "different grids")
@@ -14,16 +14,16 @@ test_that("concatenation behaves for tfd", {
 })
 
 
-tfb_k10 = x %>% tfb(k = 10)
-tfb_k20 = x_irr %>% tfb(k = 20)
-z = tf_rgp(10, arg = seq(0, 1, length.out = 11)) %>% tfb_fpc()
-z2 = z %>% tfb_fpc(npc = 10)
+tfb_k10 <- x %>% tfb(k = 10)
+tfb_k20 <- x_irr %>% tfb(k = 20)
+z <- tf_rgp(10, arg = seq(0, 1, length.out = 11)) %>% tfb_fpc()
+z2 <- z %>% tfb_fpc(npc = 10)
 
 test_that("concatenation behaves for tfb", {
   expect_is(c(tfb_k10[1], tfb_k10[2]), "tfb_spline")
   expect_is(c(tfb(tfb_k10[1]), tfb(tfb_k10[2])), "tfb_spline")
   expect_is(c(z, z), "tfb_fpc")
-  
+
   expect_warning(c(tfb_k10, tfb_k20))
   expect_error(c(tfb_k10, tfb_fpc(z)))
   expect_error(c(z, tfb_k10))

--- a/tests/testthat/test-where.R
+++ b/tests/testthat/test-where.R
@@ -1,7 +1,7 @@
 context("tf_where")
 
 test_that("tf_where basics work", {
-  lin <- 1:2 * tfd(seq(-1, 1, l = 11), seq(-1, 1, l = 11)) + c(0, 0.1)
+  lin <- 1:2 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11)) + c(0, 0.1)
   expect_equivalent(
     tf_where(lin, value %inr% c(-1, -.5)),
     list(c(-1.0, -0.8, -0.6), c(-0.4))

--- a/tests/testthat/test-zoom.R
+++ b/tests/testthat/test-zoom.R
@@ -1,7 +1,7 @@
 context("tf_zoom")
 
 set.seed(123)
-x <- tf_rgp(4, arg = seq(0, 1, l = 51), nugget = .1)
+x <- tf_rgp(4, arg = seq(0, 1, length.out = 51), nugget = .1)
 xi <- tf_sparsify(tf_jiggle(x), .2)
 xb <- tfb(x, verbose = FALSE)
 xbi <- tfb(xi, verbose = FALSE)
@@ -22,7 +22,7 @@ test_that("tf_zoom for tfd works", {
   expect_error(tf_zoom(x, .11, .111), "no data")
   expect_error(tf_zoom(xi, 0.051, 0.0511), "no data")
 
-  expect_true(is_irreg(tf_zoom(x, .2, seq(.3, 1, l = length(x)))))
+  expect_true(is_irreg(tf_zoom(x, .2, seq(.3, 1, length.out = length(x)))))
 })
 
 
@@ -41,8 +41,8 @@ test_that("tf_zoom for tfb_spline works", {
   expect_error(tf_zoom(xb, c(.8, .1)))
   expect_error(tf_zoom(xb, .11, .111), "no data")
 
-  expect_message(tf_zoom(xb, .2, seq(.3, 1, l = length(x))), "converting to tfd")
-  expect_true(is_irreg(tf_zoom(xb, .2, seq(.3, 1, l = length(x)))))
+  expect_message(tf_zoom(xb, .2, seq(.3, 1, length.out = length(x))), "converting to tfd")
+  expect_true(is_irreg(tf_zoom(xb, .2, seq(.3, 1, length.out = length(x)))))
 })
 
 test_that("tf_zoom for tfb_fpc works", {
@@ -64,6 +64,6 @@ test_that("tf_zoom for tfb_fpc works", {
   expect_error(suppressWarnings(tf_zoom(xfpc, .8, .1)))
   expect_error(suppressWarnings(tf_zoom(xfpc, .11, .111)), "no data")
   expect_true(suppressWarnings(
-    is_irreg(tf_zoom(xfpc, .2, seq(.3, 1, l = length(x))))))
+    is_irreg(tf_zoom(xfpc, .2, seq(.3, 1, length.out = length(x))))))
 })
 


### PR DESCRIPTION
change to full length.out arg in seq instead of partial matching, refactored description file to follow tidy format and changed & to && where applicable