### PR TITLE
refactor: change to lambda functions in purrr, replace vapply w/ purr…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 Collate:
     'approx.R'
     'brackets.R'

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -3,7 +3,7 @@
 #' These functions access, subset, replace and evaluate `tf` objects.
 #' For more information on creating `tf` objects and converting them to/from
 #' `list`, `data.frame` or `matrix`, see [tfd()] and [tfb()]. See Details.\cr
-#' 
+#'
 #' Note that these break certain (terrible) R conventions for vector-like objects:\cr
 #'
 #' - no argument recycling,
@@ -21,7 +21,7 @@
 #' @param i index of the observations (`integer`ish, `character` or `logical`,
 #'   usual R rules apply)
 #' @param j The `arg` used to evaluate the functions. A (list of) `numeric`
-#'   vectors. *NOT* interpreted as a column number but as the argument value of 
+#'   vectors. *NOT* interpreted as a column number but as the argument value of
 #'   the respective functional datum.
 #' @param interpolate should functions be evaluated (i.e., inter-/extrapolated)
 #'   for values in `arg` for which no original data is available? Only relevant for
@@ -44,8 +44,9 @@
 #' @export
 #' @aliases tfbrackets
 #' @family tidyfun bracket-operator
-#' @examples 
-#' (x <- 1:3 * tfd(data = 0:10, arg = 0:10)); plot(x)
+#' @examples
+#' (x <- 1:3 * tfd(data = 0:10, arg = 0:10))
+#' plot(x)
 #' # this operator's 2nd argument is quite overloaded -- you can:
 #' # 1. simply extract elements from the vector if no second arg is given:
 #' x[1]
@@ -53,10 +54,10 @@
 #' x[-(2:3)]
 #' # 2. use the second argument and optional additional arguments to
 #' #    extract specific function evaluations in a number of formats:
-#' x[1:2 , c(4.5, 9)] #returns a matrix of function evaluations
-#' x[1:2 , c(4.5, 9), interpolate = FALSE] # NA for arg-values not in the original data
-#' x[-3 , seq(1, 9, by = 2), matrix = FALSE] #list of data.frames for each function
-#' # in order to evaluate a set of observed functions on a new grid and 
+#' x[1:2, c(4.5, 9)] # returns a matrix of function evaluations
+#' x[1:2, c(4.5, 9), interpolate = FALSE] # NA for arg-values not in the original data
+#' x[-3, seq(1, 9, by = 2), matrix = FALSE] # list of data.frames for each function
+#' # in order to evaluate a set of observed functions on a new grid and
 #' # save them as a functional data vector again, use `tfd` or `tfb` instead:
 #' tfd(x, arg = seq(0, 10, by = .01), resolution = 1e-3)
 `[.tf` <- function(x, i, j, interpolate = TRUE, matrix = TRUE) {
@@ -97,11 +98,11 @@
   }
   evals <- tf_evaluate(x, arg = j)
   if (!interpolate) {
-    new_j <- map2(j, ensure_list(tf_arg(x)), ~!(.x %in% .y))
+    new_j <- map2(j, ensure_list(tf_arg(x)), \(x, y) !(x %in% y))
     if (any(unlist(new_j))) {
       warning("interpolate = FALSE & no evaluations for some <j>: NAs created.")
     }
-    evals <- map2(evals, new_j, ~ifelse(.y, NA, .x))
+    evals <- map2(evals, new_j, \(x, y) ifelse(y, NA, x))
   }
   if (matrix) {
     ret <- do.call(rbind, evals)
@@ -109,7 +110,7 @@
     rownames(ret) <- names(x)
     structure(ret, arg = unlist(j))
   } else {
-    ret <- map2(j, evals, ~ data.frame(arg = .x, value = .y))
+    ret <- map2(j, evals, \(x, y) data.frame(arg = x, value = y))
     names(ret) <- names(x)
     ret
   }
@@ -169,7 +170,7 @@
   ret <- unclass(x)
   ret[i] <- unclass(value)
   # fill up empty functions
-  na_entries <- which(vapply(ret, is.null, logical(1)))
+  na_entries <- which(map_lgl(ret, is.null))
   if (length(na_entries)) {
     nas <- if (is_irreg(x)) {
       replicate(length(na_entries), list(arg = attr_x$domain[1], value = NA),

--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -12,7 +12,7 @@ tf_2_df <- function(tf, arg, interpolate = TRUE, ...) {
   
   tmp <- do.call(rbind, 
                  args = tf[, arg, matrix = FALSE, interpolate = interpolate])
-  n_evals <- vapply(arg, length, numeric(1))
+  n_evals <- map_dbl(arg, length)
   tmp$id <-
     if (length(n_evals) == 1) {
       rep(unique_id(names(tf)) %||% seq_along(tf), each = n_evals)

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -39,8 +39,8 @@ tf_evaluate.tfd <- function(object, arg, evaluator = tf_evaluator(object), ...) 
   assert_arg(arg, object, check_unique = FALSE)
   ret <- pmap(
     list(arg, ensure_list(tf_arg(object)), tf_evaluations(object)),
-    ~evaluate_tfd_once(
-      new_arg = ..1, arg = ..2, evaluations = ..3,
+    \(x, y, z) evaluate_tfd_once(
+      new_arg = x, arg = y, evaluations = z,
       evaluator = evaluator,
       resolution = tf_resolution(object)
     )
@@ -91,8 +91,8 @@ tf_evaluate.tfb <- function(object, arg, ...) {
   } else {
     ret <- pmap(
       list(arg, ensure_list(tf_arg(object)), coef(object)),
-      ~evaluate_tfb_once(
-        x = ..1, arg = ..2, coefs = ..3,
+      \(x, y, z) evaluate_tfb_once(
+        x = x, arg = y, coefs = z,
         basis = attr(object, "basis"), X = attr(object, "basis_matrix"),
         resolution = tf_resolution(object)
       )

--- a/R/math.R
+++ b/R/math.R
@@ -1,9 +1,9 @@
 # utility function for linear operations that can be done on coefs or evaluations directly.
 fun_math <- function(x, op) {
   attr_ret <- attributes(x)
-  ret <- map(tf_evaluations(x), ~do.call(op, list(x = .x)))
+  ret <- map(tf_evaluations(x), \(x) do.call(op, list(x = x)))
   if (is_irreg(x)) {
-    ret <- map2(tf_arg(x), ret, ~list(arg = .x, value = .y))
+    ret <- map2(tf_arg(x), ret, \(x, y) list(arg = x, value = y))
   }
   attributes(ret) <- attr_ret
   ret

--- a/R/methods.R
+++ b/R/methods.R
@@ -45,7 +45,7 @@ tf_evaluations.tfd_irreg <- function(f) {
 
 #' @export
 tf_evaluations.tfb <- function(f) {
-  evals <- map(f, ~ drop(attr(f, "basis_matrix") %*% .))
+  evals <- map(f, \(x) drop(attr(f, "basis_matrix") %*% x))
   if (!inherits(f, "tfb_fpc")) {
     evals <- map(evals, attr(f, "family")$linkinv)
   }
@@ -101,9 +101,9 @@ tf_evaluator <- function(f) {
 #' @param value **for `tf_evaluator<-`:** (bare or quoted) name of a function that
 #'   can be used to interpolate an `tfd`. Needs to accept vector arguments `x`,
 #'   `arg`, `evaluations` and return evaluations of the function defined by
-#'   `arg`, `evaluations` at `x`. \cr  
-#'   **for `tf_arg<-`:** (list of) new `arg`-values. \cr  
-#'   **for `td_domain<-`:** sorted numeric vector with the 2 new endpoints of 
+#'   `arg`, `evaluations` at `x`. \cr
+#'   **for `tf_arg<-`:** (list of) new `arg`-values. \cr
+#'   **for `td_domain<-`:** sorted numeric vector with the 2 new endpoints of
 #'     the domain.
 #' @export
 `tf_evaluator<-` <- function(x, value) {
@@ -132,8 +132,12 @@ tf_evaluator <- function(f) {
 tf_basis <- function(f, as_tfd = FALSE) {
   stopifnot(inherits(f, "tfb"))
   basis <- attr(f, "basis")
-  if (!as_tfd) return(basis)
-  basis(tf_arg(f)) |> t() |> tfd(arg = tf_arg(f))
+  if (!as_tfd) {
+    return(basis)
+  }
+  basis(tf_arg(f)) |>
+    t() |>
+    tfd(arg = tf_arg(f))
 }
 
 #-------------------------------------------------------------------------------
@@ -141,8 +145,10 @@ tf_basis <- function(f, as_tfd = FALSE) {
 #' @rdname tfmethods
 #' @export
 `tf_arg<-` <- function(x, value) {
-  warning(c("this changes arg without changing the corresponding function values!\n", 
-          "use tf_interpolate to re-evaluate functions on a new grid."))
+  warning(c(
+    "this changes arg without changing the corresponding function values!\n",
+    "use tf_interpolate to re-evaluate functions on a new grid."
+  ))
   UseMethod("tf_arg<-")
 }
 
@@ -150,7 +156,7 @@ tf_basis <- function(f, as_tfd = FALSE) {
 #' @export
 `tf_arg<-.tfd_irreg` <- function(x, value) {
   assert_arg(value, x)
-  ret <- map2(tf_evaluations(x), value, ~list(arg = .y, data = .x))
+  ret <- map2(tf_evaluations(x), value, \(x, y) list(arg = y, data = x))
   attributes(ret) <- attributes(x)
   ret
 }
@@ -196,12 +202,12 @@ rev.tf <- function(x) {
 #' @rdname tfmethods
 #' @export
 is.na.tf <- function(x) {
-  map_lgl(unclass(x), ~is.na(.x)[1])
+  map_lgl(unclass(x), \(x) is.na(x)[1])
 }
 #' @rdname tfmethods
 #' @export
 is.na.tfd_irreg <- function(x) {
-  map_lgl(unclass(x), ~is.na(.x$value[1]))
+  map_lgl(unclass(x), \(x) is.na(x$value[1]))
 }
 
 
@@ -213,11 +219,11 @@ is_tf <- function(x) inherits(x, "tf")
 
 #' @rdname tfmethods
 #' @export
-is_tfd <- function(x)  inherits(x, "tfd")
+is_tfd <- function(x) inherits(x, "tfd")
 
 #' @rdname tfmethods
 #' @export
-is_reg <- function(x)  inherits(x, "tfd_reg")
+is_reg <- function(x) inherits(x, "tfd_reg")
 
 #' @rdname tfmethods
 #' @export
@@ -225,7 +231,7 @@ is_tfd_reg <- is_reg
 
 #' @rdname tfmethods
 #' @export
-is_irreg <- function(x) inherits(x,"tfd_irreg")
+is_irreg <- function(x) inherits(x, "tfd_irreg")
 
 #' @rdname tfmethods
 #' @export

--- a/R/ops.R
+++ b/R/ops.R
@@ -31,7 +31,7 @@ fun_op <- function(x, y, op, numeric = NA) {
   if (is_tfb(y)) y_ <- coef(y)
   if (is_tfd(y)) y_ <- tf_evaluations(y)
   if (isTRUE(numeric == 2)) y_ <- y
-  ret <- map2(x_, y_, ~do.call(op, list(e1 = .x, e2 = .y)))
+  ret <- map2(x_, y_, \(x, y) do.call(op, list(e1 = x, e2 = y)))
   if ("tfd" %in% attr_ret$class) {
     if (is.na(numeric) &&
       (attr(x, "evaluator_name") != attr(y, "evaluator_name"))) {
@@ -41,7 +41,7 @@ fun_op <- function(x, y, op, numeric = NA) {
       )
     }
     if ("tfd_irreg" %in% attr_ret$class) {
-      ret <- map2(arg_ret, ret, ~list(arg = .x, value = .y))
+      ret <- map2(arg_ret, ret, \(x, y) list(arg = x, value = y))
     }
   }
   attributes(ret) <- attr_ret
@@ -116,7 +116,7 @@ Ops.tf <- function(e1, e2) {
   # not comparing names, as per convention...
   same <- all(compare_tf_attribs(e1, e2))
   if (!same) return(rep(FALSE, max(length(e1), length(e2))))
-  unlist(map2(e1, e2, ~isTRUE(all.equal(.x, .y))))
+  unlist(map2(e1, e2, \(x, y) isTRUE(all.equal(x, y))))
 }
 
 #' @rdname tfgroupgenerics

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -11,28 +11,28 @@ string_rep_tf <- function(f, signif_arg = NULL,
   )
   arg_ch <- map2(
     ensure_list(tf_arg(f)), show,
-    ~do.call(format, c(format_args, list(x = .x[1:.y])))
+    \(x, y) do.call(format, c(format_args, list(x = x[1:y])))
   )
   value_ch <- map2(
     tf_evaluations(f), show,
-    ~do.call(format, c(format_args, list(x = .x[1:.y])))
+    \(x, y) do.call(format, c(format_args, list(x = x[1:y])))
   )
-  arg_nchar <- map(arg_ch, ~nchar(.x)) |> unlist() |> max()
-  value_nchar <- map(value_ch, ~nchar(.x)) |> unlist() |> max()
-  #left-pad with spaces:
-  arg_ch <- map(arg_ch, ~ sprintf(paste0("%", arg_nchar, "s"), .)) 
-  value_ch <- map(value_ch, ~ sprintf(paste0("%", value_nchar, "s"), .))
+  arg_nchar <- map(arg_ch, \(x) nchar(x)) |>
+    unlist() |>
+    max()
+  value_nchar <- map(value_ch, \(x) nchar(x)) |>
+    unlist() |>
+    max()
+  # left-pad with spaces:
+  arg_ch <- map(arg_ch, \(x) sprintf(paste0("%", arg_nchar, "s"), x))
+  value_ch <- map(value_ch, \(x) sprintf(paste0("%", value_nchar, "s"), x))
   str <- map2(
-    arg_ch, value_ch,
-    ~paste(paste0("(", .x, ",", .y, ")"), collapse = ";")
+    arg_ch, value_ch, \(x, y) paste(paste0("(", x, ",", y, ")"), collapse = ";")
   )
   str <- pmap(
-    list(str, arg_len, show),
-    ~ifelse(..2 > ..3, paste0(..1, "; ..."), ..1)
+    list(str, arg_len, show), \(x, y, z) ifelse(y > z, paste0(x, "; ..."), x)
   )
-  map_if(str, grepl("NA\\)", str), ~{
-    "NA"
-  })
+  map_if(str, grepl("NA\\)", str), \(x) NA)
 }
 
 #-------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ print.tfd_reg <- function(x, n = 10, ...) {
 #' @export
 print.tfd_irreg <- function(x, n = 10, ...) {
   NextMethod()
-  nas <- map_lgl(tf_evaluations(x), ~length(.) == 1 && all(is.na(.)))
+  nas <- map_lgl(tf_evaluations(x), \(x) length(x) == 1 && all(is.na(x)))
   n_evals <- tf_count(x[!nas])
   cat(paste0(
     " based on ", min(n_evals), " to ", max(n_evals), " (mean: ",
@@ -122,10 +122,9 @@ format.tf <- function(x, digits = 2, nsmall = 0, width = options()$width,
     } else {
       paste0("[", seq_along(str), "]")
     }
-    str <- map2(prefix, str, ~paste0(.x, ": ", .y))
+    str <- map2(prefix, str, \(x, y) paste0(x, ": ", y))
   }
   unlist(map_if(
-    str, ~nchar(.x) > width,
-    ~paste0(substr(.x, 1, width - 3), "...")
+    str, \(x) nchar(x) > width, \(x) paste0(substr(x, 1, width - 3), "...")
   ))
 }

--- a/R/rng.R
+++ b/R/rng.R
@@ -1,14 +1,14 @@
 #' Gaussian Process random generator
 #'
-#' Generates `n` realizations of a zero-mean Gaussian process. 
-#' The function also accepts user-defined covariance functions (without "nugget" effect, see `cov`), 
-#' The implemented defaults with `scale` parameter \eqn{\phi}, `order` \eqn{o} and `nugget` effect variance \eqn{\sigma^2} are:  
+#' Generates `n` realizations of a zero-mean Gaussian process.
+#' The function also accepts user-defined covariance functions (without "nugget" effect, see `cov`),
+#' The implemented defaults with `scale` parameter \eqn{\phi}, `order` \eqn{o} and `nugget` effect variance \eqn{\sigma^2} are:
 #' - *squared exponential* covariance \eqn{Cov(x(t), x(t')) = \exp(-(t-t')^2)/\phi) + \sigma^2
 #' \delta_{t}(t')}.
 #' - *Wiener* process covariance \eqn{Cov(x(t), x(t')) =
-#' \min(t',t)/\phi + \sigma^2 \delta_{t}(t')}, 
+#' \min(t',t)/\phi + \sigma^2 \delta_{t}(t')},
 #' -  [*Matèrn* process](https://en.wikipedia.org/wiki/Mat%C3%A9rn_covariance_function#Definition) covariance \eqn{Cov(x(t), x(t')) =
-#' \tfrac{2^{1-o}}{\Gamma(o)}(\tfrac{\sqrt{2o}|t-t'|}{\phi})^o\text{Bessel}_o(\tfrac{\sqrt{2o}|t-t'|}{s}) + \sigma^2 \delta_{t}(t')}  
+#' \tfrac{2^{1-o}}{\Gamma(o)}(\tfrac{\sqrt{2o}|t-t'|}{\phi})^o\text{Bessel}_o(\tfrac{\sqrt{2o}|t-t'|}{s}) + \sigma^2 \delta_{t}(t')}
 #'
 #' @param n how many realizations to draw
 #' @param arg vector of evaluation points (`arg` of the return object). Defaults
@@ -17,8 +17,8 @@
 #' @param scale scale parameter (see Description). Defaults to the width of the
 #'   domain divided by 10.
 #' @param cov type of covariance function to use. Implemented defaults are
-#'   `"squareexp"`, `"wiener"`, `"matern"`, see Description. Can also be any 
-#'     vectorized function returning \eqn{Cov(x(t), x(t'))} *without nugget effect* 
+#'   `"squareexp"`, `"wiener"`, `"matern"`, see Description. Can also be any
+#'     vectorized function returning \eqn{Cov(x(t), x(t'))} *without nugget effect*
 #'     for pairs of inputs t and t'.
 #' @param nugget nugget effect for additional white noise / unstructured variability.
 #'  Defaults to `scale/200` (so: very little white noise).
@@ -29,34 +29,34 @@
 #' @importFrom mvtnorm rmvnorm
 #' @export
 #' @family tidyfun RNG functions
-tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"), 
+tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"),
                    scale = diff(range(arg)) / 10, nugget = scale / 200, order = 1.5) {
   if (!is.function(cov)) {
     cov <- match.arg(cov)
-    f_cov <- switch(
-      cov, 
+    f_cov <- switch(cov,
       "wiener" = function(s, t) pmin(s, t) / scale,
-      "squareexp" = function(s, t) exp( -(s - t)^2 / scale), 
+      "squareexp" = function(s, t) exp(-(s - t)^2 / scale),
       "matern" = function(s, t) {
         r <- sqrt(2 * order) * abs(s - t) / scale
-        cov <- 2^(1 - order) / gamma(order) * r^order  * base::besselK(r, nu = order)
+        cov <- 2^(1 - order) / gamma(order) * r^order * base::besselK(r, nu = order)
         cov[s == t] <- 1
         cov
-      })
+      }
+    )
   } else {
     assert_function(cov, nargs = 2)
     f_cov <- cov
   }
-  
+
   if (length(arg) == 1) {
     assert_integerish(arg, lower = 1)
     arg <- seq(0, 1, length.out = arg)
-  } 
+  }
   assert_numeric(arg, any.missing = FALSE, unique = TRUE)
   assert_number(n, lower = 1)
   assert_number(scale, lower = 0)
   assert_number(nugget, lower = 0)
-  
+
   cov <- outer(arg, arg, f_cov) + diag(0 * arg + nugget)
   y <- rmvnorm(n, mean = 0 * arg, sigma = cov)
   tfd(y, arg = arg)
@@ -64,7 +64,7 @@ tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"),
 
 #' Make a `tf` (more) irregular
 #'
-#' Randomly create some irregular functional data from regular ones.  
+#' Randomly create some irregular functional data from regular ones.
 #' **jiggle** it by randomly moving around its `arg`-values. Only for `tfd`.
 #' **sparsify** it by setting (100*`dropout`)% of its values to `NA`.
 #'
@@ -87,15 +87,16 @@ tf_jiggle <- function(f, amount = .4, ...) {
 tf_jiggle_args <- function(arg, amount) {
   diffs <- diff(arg)
   n <- length(arg)
-  
-  #push left/right at most (amount*100)% of distance to adjacent gridpoint
+
+  # push left/right at most (amount*100)% of distance to adjacent gridpoint
   push_left_right <- sample(c(-1, 1), n - 2, replace = TRUE)
-  use_diffs <- ifelse(push_left_right == -1, 
-                      diffs[1:(n - 2)],
-                      diffs[2:(n - 1)]) 
+  use_diffs <- ifelse(push_left_right == -1,
+    diffs[1:(n - 2)],
+    diffs[2:(n - 1)]
+  )
   tf_jiggle <- runif(n - 2, 0, amount) * use_diffs * push_left_right
   new_args <- arg[2:(n - 1)] + tf_jiggle
-  
+
   c(
     runif(1, arg[1], new_args[1]), new_args,
     runif(1, new_args[n - 2], arg[n])
@@ -110,18 +111,13 @@ tf_jiggle_args <- function(arg, amount) {
 tf_sparsify <- function(f, dropout = .5, ...) {
   stopifnot(is_tf(f))
   nas <- map(
-    tf_evaluations(f),
-    ~ifelse(runif(length(.x)) < dropout, TRUE, FALSE)
+    tf_evaluations(f), \(x) ifelse(runif(length(x)) < dropout, TRUE, FALSE)
   )
-  tf_evals <- map2(
-    tf_evaluations(f), nas,
-    ~ .x[!.y]
-  )
+  tf_evals <- map2(tf_evaluations(f), nas, \(x, y) x[!y])
   tf_args <- ensure_list(tf_arg(f))
-  tf_args <- map2(
-    tf_args, nas,
-    ~ .x[!.y]
+  tf_args <- map2(tf_args, nas, \(x, y) x[!y])
+  tfd.list(tf_evals, tf_args,
+    resolution = attr(f, "resolution"),
+    domain = tf_domain(f)
   )
-  tfd.list(tf_evals, tf_args, resolution = attr(f, "resolution"), 
-      domain = tf_domain(f))
 }

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -32,9 +32,11 @@ tf_smooth <- function(x, ...) {
 #' @export
 #' @rdname tf_smooth
 tf_smooth.tfb <- function(x, ...) {
-  warning("you called tf_smooth on a tfb object, not on a tfd object -- ",
-          "just use a smaller basis or stronger penalization.\n",
-          "Returning unchanged tfb object.")
+  warning(
+    "you called tf_smooth on a tfb object, not on a tfd object -- ",
+    "just use a smaller basis or stronger penalization.\n",
+    "Returning unchanged tfb object."
+  )
   x
 }
 
@@ -56,14 +58,14 @@ tf_smooth.tfb <- function(x, ...) {
 #' layout(t(1:4))
 #' plot(f, points = FALSE, main = "original")
 #' plot(f_lowess, points = FALSE, col = "blue", main = "lowess (default,\n span .9 in red)")
-#' lines(tf_smooth(f, "lowess", f = .9), col = "red", alpha= .2)
+#' lines(tf_smooth(f, "lowess", f = .9), col = "red", alpha = .2)
 #' plot(f_mean, points = FALSE, col = "blue", main = "rolling means &\n medians (red)")
-#' lines(f_median, col = "red", alpha= .2) # note constant extrapolation at both ends!
+#' lines(f_median, col = "red", alpha = .2) # note constant extrapolation at both ends!
 #' plot(f, points = FALSE, main = "orginal and\n savgol (red)")
 #' lines(f_sg, col = "red")
-tf_smooth.tfd <-
-  function(x, method = c("lowess", "rollmean", "rollmedian", "savgol"),
-           ...) {
+tf_smooth.tfd <- function(x,
+                          method = c("lowess", "rollmean", "rollmedian", "savgol"),
+                          ...) {
   method <- match.arg(method)
   smoother <- get(method, mode = "function")
   dots <- list(...)
@@ -78,7 +80,9 @@ tf_smooth.tfd <-
       if (is.null(dots$k)) {
         dots$k <- ceiling(.05 * min(tf_count(x)))
         dots$k <- dots$k + !(dots$k %% 2) # make uneven
-        message("using k = ", dots$k, " observations for rolling data window.")
+        message(
+          "using k = ", dots$k, " observations for rolling data window."
+        )
       }
       if (is.null(dots$fill)) {
         message("setting fill = 'extend' for start/end values.")
@@ -89,12 +93,15 @@ tf_smooth.tfd <-
       if (is.null(dots$fl)) {
         dots$fl <- ceiling(.15 * min(tf_count(x)))
         dots$fl <- dots$fl + !(dots$fl %% 2) # make uneven
-        message("using fl = ", dots$fl, " observations for rolling data window.")
+        message(
+          "using fl = ", dots$fl, " observations for rolling data window."
+        )
       }
     }
 
-    smoothed <- map(tf_evaluations(x),
-                    ~ do.call(smoother, append(list(.x), dots)))
+    smoothed <- map(
+      tf_evaluations(x), \(x) do.call(smoother, append(list(x), dots))
+    )
   }
 
   if (method == "lowess") {
@@ -102,15 +109,16 @@ tf_smooth.tfd <-
       dots$f <- .15
       message("using f = ", dots$f, " as smoother span for lowess")
     }
-    smoothed <- map(tf_evaluations(x),
-                    ~do.call(smoother, append(list(.x), dots))$y)
+    smoothed <- map(
+      tf_evaluations(x), \(x) do.call(smoother, append(list(x), dots))$y
+    )
   }
 
   tfd(smoothed, tf_arg(x),
     evaluator = !!attr(x, "evaluator_name"),
     resolution = attr(x, "resolution"), domain = tf_domain(x)
   )
-  }
+}
 
 #' @export
 tf_smooth.default <- function(x, ...) .NotYetImplemented()

--- a/R/tfb-spline-utils.R
+++ b/R/tfb-spline-utils.R
@@ -37,7 +37,7 @@ smooth_spec_wrapper <- function(spec, deriv = 0, eps = 1e-6) {
         data = data.frame(arg = arg_interleave)
       )
       apply(X, 2, function(arg, x) cumsum(quad_trapez(arg, x)),
-            arg = arg_interleave
+        arg = arg_interleave
       )[new_args, ]
     })
   }
@@ -47,7 +47,7 @@ smooth_spec_wrapper <- function(spec, deriv = 0, eps = 1e-6) {
 
 #----------------- Unpenalized LS fits -----------------------------------------
 
-fit_unpenalized <- function(data, spec_object, gam_args, arg_u, regular, 
+fit_unpenalized <- function(data, spec_object, gam_args, arg_u, regular,
                             ls_fit) {
   if (ls_fit) {
     return(fit_unpenalized_ls(data, spec_object, arg_u, regular))
@@ -70,11 +70,11 @@ fit_unpenalized_ls <- function(data, spec_object, arg_u, regular) {
     index_list <- split(attr(arg_u, "index"), data$id)
     coef_list <- map2(
       index_list, eval_list,
-      ~ qr.coef(qr = qr(spec_object$X[.x, ]), y = .y)
+      \(x, y) qr.coef(qr = qr(spec_object$X[x, ]), y = y)
     )
     pve <- unlist(map2(
       index_list, eval_list,
-      ~1 - var(qr.resid(qr = qr(spec_object$X[.x, ]), y = .y)) / var(.y)
+      \(x, y) 1 - var(qr.resid(qr = qr(spec_object$X[x, ]), y = y)) / var(y)
     ))
   }
   names(coef_list) <- levels(data$id)
@@ -84,39 +84,45 @@ fit_unpenalized_ls <- function(data, spec_object, arg_u, regular) {
 #---Penalized LS fits          -------------------------------------------------
 
 
-# utility functions for penalized spline representation: 
+# utility functions for penalized spline representation:
 # global fit, curve-specific LS, curve-specific GLM
-fit_penalized <- function(data, spec_object, gam_args, arg_u, regular, global, 
-                          ls_fit) { 
-  
+fit_penalized <- function(data, spec_object, gam_args, arg_u, regular, global,
+                          ls_fit) {
   if (global && gam_args$sp == -1) {
     # find a suitable global level of smoothing based on a pilot estimate
     # uses 10% of curves, at most 100, at least 5
     # uses median of the smothing parameters on this pilot sample.
-    pilot_id <- round(seq(from = 1, to = nlevels(data$id), 
-                    length.out = max(1, 
-                                 min(max(5, 0.1 * nlevels(data$id)), 100))))
+    pilot_id <- round(seq(
+      from = 1, to = nlevels(data$id),
+      length.out = max(
+        1,
+        min(max(5, 0.1 * nlevels(data$id)), 100)
+      )
+    ))
     pilot_id <- levels(data$id)[unique(pilot_id)]
     arg_u_pilot <- arg_u
     attr(arg_u_pilot, "index") <- attr(arg_u_pilot, "index")[data$id %in% pilot_id]
-    data_pilot <- subset(data, data$id %in% pilot_id)  |> droplevels()
+    data_pilot <- subset(data, data$id %in% pilot_id) |> droplevels()
     if (!ls_fit) {
-      pilot_sp <- 
+      pilot_sp <-
         fit_ml(
-          data_pilot, spec_object, gam_args, arg_u_pilot, penalized = TRUE
-          )$sp
+          data_pilot, spec_object, gam_args, arg_u_pilot,
+          penalized = TRUE
+        )$sp
     } else {
-      pilot_sp <- 
+      pilot_sp <-
         fit_penalized_ls(
           data_pilot, spec_object, arg_u_pilot, gam_args, regular
-          )$sp
+        )$sp
     }
-    gam_args$sp <- exp(mean(log(pilot_sp))) #median?
+    gam_args$sp <- exp(mean(log(pilot_sp))) # median?
   }
   if (!ls_fit) {
-    return(fit_ml(data, spec_object, gam_args, arg_u, penalized = TRUE, 
-                  sp = gam_args$sp))
-  } 
+    return(fit_ml(data, spec_object, gam_args, arg_u,
+      penalized = TRUE,
+      sp = gam_args$sp
+    ))
+  }
   fit_penalized_ls(data, spec_object, arg_u, gam_args, regular)
 }
 
@@ -126,13 +132,15 @@ fit_penalized_ls <- function(data, spec_object, arg_u, gam_args, regular) {
   gam_args <- gam_args[names(gam_args) %in% names(formals(mgcv::magic))]
   ret <- map2(
     index_list, eval_list,
-    ~ purrr::possibly(magic_smooth_coef, 
-                        quiet = FALSE,
-                        otherwise = list(
-                          coef = rep(NA_real_, ncol(spec_object$X)),
-                          pve = NA_real_,
-                          sp = NA_real_))
-                        (.y, .x, spec_object, gam_args)
+    \(x, y) possibly(magic_smooth_coef,
+      quiet = FALSE,
+      otherwise = list(
+        coef = rep(NA_real_, ncol(spec_object$X)),
+        pve = NA_real_,
+        sp = NA_real_
+      )
+    )
+    (y, x, spec_object, gam_args)
   )
   sp <- unlist(map(ret, "sp"))
   pve <- unlist(map(ret, "pve"))
@@ -143,10 +151,12 @@ fit_penalized_ls <- function(data, spec_object, arg_u, gam_args, regular) {
 magic_smooth_coef <- function(evaluations, index, spec_object, gam_args) {
   fixed_sp <- gam_args$sp != -1
   magic_args <- c(
-    list(y = evaluations, 
-         X = spec_object$X[index, ], 
-         S = if (fixed_sp) list() else spec_object$S,
-         H = if (fixed_sp) gam_args$sp * spec_object$S[[1]] else NULL),
+    list(
+      y = evaluations,
+      X = spec_object$X[index, ],
+      S = if (fixed_sp) list() else spec_object$S,
+      H = if (fixed_sp) gam_args$sp * spec_object$S[[1]] else NULL
+    ),
     flatten(list(off = 1, gam_args))
   )
   m <- do.call(mgcv::magic, magic_args)
@@ -157,24 +167,27 @@ magic_smooth_coef <- function(evaluations, index, spec_object, gam_args) {
 #------ General Likelihood Fits ------------------------------------------------
 
 # fit gam for one curve, with estimated (default, sp=-1) or fixed penalization
-#  or unpenalized 
+#  or unpenalized
 fit_ml <- function(data, spec_object, gam_args, arg_u, penalized, sp = -1) {
   eval_list <- split(data$value, data$id)
   index_list <- split(attr(arg_u, "index"), data$id)
   arg_u$X <- spec_object$X
   if (penalized) {
     gam_args$paraPen <- quote(list(X = spec_object$S))
-    gam_args$sp <- NULL #weirdness ensues otherwise, restored below
-  }  
-  gam_prep <- do.call(gam, 
-                      c(list(formula = x ~ 0 + X, data = arg_u), 
-                        fit = FALSE, gam_args))
+    gam_args$sp <- NULL # weirdness ensues otherwise, restored below
+  }
+  gam_prep <- do.call(
+    gam,
+    c(list(formula = x ~ 0 + X, data = arg_u),
+      fit = FALSE, gam_args
+    )
+  )
   gam_prep$sig2 <- -1 # GCV switch --
-                      # needs to be set explicitly so magic does not get NA
-                      # as 11th argument when called from gam.fit
+  # needs to be set explicitly so magic does not get NA
+  # as 11th argument when called from gam.fit
   if (!penalized) {
     fixed_sp <- TRUE
-    gam_prep$sp <- NULL #gam expects this to be nameable otherwise
+    gam_prep$sp <- NULL # gam expects this to be nameable otherwise
     sp <- NULL
   } else {
     fixed_sp <- sp != -1
@@ -184,27 +197,32 @@ fit_ml <- function(data, spec_object, gam_args, arg_u, penalized, sp = -1) {
     }
     gam_prep$sp <- sp
     gam_prep$pP$sp[1] <- sp
-  } 
+  }
   ret <- map2(
-    index_list, eval_list, 
-    ~ purrr::possibly(fit_ml_once, 
-                      quiet = FALSE,
-                      otherwise = list(
-                        coef = rep(NA_real_, ncol(spec_object$X)),
-                        pve = NA_real_,
-                        sp = NA_real_)
-                      )(.x, .y, gam_prep = gam_prep, sp = sp)
+    index_list, eval_list,
+    \(x, y) possibly(fit_ml_once,
+      quiet = FALSE,
+      otherwise = list(
+        coef = rep(NA_real_, ncol(spec_object$X)),
+        pve = NA_real_,
+        sp = NA_real_
+      )
+    )(x, y, gam_prep = gam_prep, sp = sp)
   )
   names(ret) <- levels(data$id)
   coef <- map(ret, "coef")
-  failed <- which(map_lgl(coef, ~ any(is.na(.))))
+  failed <- which(map_lgl(coef, \(x) any(is.na(x))))
   if (length(failed) > 0) {
-    stop("Basis representation failed for entries:\n ", 
-         paste(unname(failed), collapse = ", "))
+    stop(
+      "Basis representation failed for entries:\n ",
+      paste(unname(failed), collapse = ", ")
+    )
   }
-  list(coef = coef, 
-       pve = map_dbl(ret, "pve"), 
-       sp = if (penalized & !fixed_sp) map_dbl(ret, "sp") else NULL)
+  list(
+    coef = coef,
+    pve = map_dbl(ret, "pve"),
+    sp = if (penalized & !fixed_sp) map_dbl(ret, "sp") else NULL
+  )
 }
 
 
@@ -216,14 +234,14 @@ fit_ml_once <- function(index, evaluations, gam_prep, sp) {
   G_tmp$w <- rep(1, G_tmp$n)
   mf <- data.frame(x = G_tmp$y)
   mf$X <- G_tmp$X
-  attributes(mf) <- attributes(G_tmp$mf )
+  attributes(mf) <- attributes(G_tmp$mf)
   G_tmp$mf <- mf
   G_tmp$offset <- rep(0, G_tmp$n)
-  m <- gam(G = G_tmp, family = G_tmp$family) 
-  list(coef = unname(m$coefficients),
-       pve = (m$null.deviance - m$deviance)/m$null.deviance,
-       # FIXME: null deviance not always defined..? (Gamma(link = inverse))
-       sp = m$sp)
+  m <- gam(G = G_tmp, family = G_tmp$family)
+  list(
+    coef = unname(m$coefficients),
+    pve = (m$null.deviance - m$deviance) / m$null.deviance,
+    # FIXME: null deviance not always defined..? (Gamma(link = inverse))
+    sp = m$sp
+  )
 }
-
-  

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -7,7 +7,7 @@ new_tfb_spline <- function(data, domain = numeric(), arg = numeric(),
   
   if (vctrs::vec_size(data) == 0) {
     
-    ret = vctrs::new_vctr(
+    ret <- vctrs::new_vctr(
       data,
       domain = domain,
       arg = arg, 
@@ -222,14 +222,14 @@ tfb_spline.numeric <- function(data, arg = NULL,
 tfb_spline.list <- function(data, arg = NULL, 
                             domain = NULL, penalized = TRUE, 
                             global = FALSE, resolution = NULL, ...) {
-  vectors <- vapply(data, is.numeric, logical(1))
+  vectors <- map_lgl(data, is.numeric)
   stopifnot(all(vectors) | !any(vectors))
   
   names_data <- names(data) 
   
   if (all(vectors)) {
-    lengths <- vapply(data, length, numeric(1))
-    if (all(lengths == lengths[1])) {
+    lens <- lengths(data)
+    if (all(lens == lens[1])) {
       data <- do.call(rbind, data)
       # dispatch to matrix method
       return(tfb_spline(data, arg, domain = domain, penalized = penalized, 
@@ -237,16 +237,16 @@ tfb_spline.list <- function(data, arg = NULL,
     } 
     stopifnot(
       !is.null(arg), length(arg) == length(data),
-      all(vapply(arg, length, numeric(1)) == lengths)
+      all(map_dbl(arg, length) == lens)
     )
-    data <- map2(arg, data, ~as.data.frame(cbind(arg = .x, value = .y)))
+    data <- map2(arg, data, \(x, y) as.data.frame(cbind(arg = x, value = y)))
   }
   dims <- map(data, dim)
   stopifnot(
-    all(vapply(dims, length, numeric(1)) == 2), all(map(dims, ~.x[2]) == 2),
+    all(lengths(dims) == 2), all(map(dims, \(x) x[2]) == 2),
     all(rapply(data, is.numeric))
   )
-  n_evals <- map(dims, ~.x[1]) 
+  n_evals <- map(dims, 1) 
   tmp <- do.call(rbind, data)
   tmp <- cbind(rep(unique_id(names(data)) %||% seq_along(data), times = n_evals), 
                tmp)  
@@ -307,15 +307,15 @@ tfb_spline.tfb <- function(data, arg = NULL,
 
 #' @export
 #' @describeIn tfb_spline convert `tfb`: default method, returning prototype when data is missing
-tfb_spline.default = function(data, arg = NULL,
-                              domain = NULL, penalized = TRUE, 
-                              global = FALSE, resolution = NULL, ...) {
+tfb_spline.default <- function(data, arg = NULL,
+                               domain = NULL, penalized = TRUE, 
+                               global = FALSE, resolution = NULL, ...) {
   
   if (!missing(data)) {
     message("input `data` not from a recognized class; returning prototype of length 0")
   }
   
-  data = data.frame()
+  data <- data.frame()
   new_tfb_spline(data, domain = domain, penalized = penalized,
                  global = global, resolution = resolution, ...)
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,7 +31,7 @@ find_arg <- function(data, arg) {
 assert_arg <- function(arg, x, check_unique = TRUE) {
   if (is.list(arg)) {
     assert_true(length(arg) %in% c(1, length(x)))
-    map(arg, ~ assert_arg_vector(., x = x, check_unique = check_unique))
+    map(arg, \(arg) assert_arg_vector(arg, x = x, check_unique = check_unique))
   } else {
     assert_arg_vector(arg, x, check_unique = check_unique)
   }
@@ -51,7 +51,7 @@ assert_arg_vector <- function(arg, x, check_unique = TRUE) {
 }
 
 get_resolution <- function(arg) {
-  min_diff <- map(ensure_list(arg), ~ min(diff(.x))) |>
+  min_diff <- map(ensure_list(arg), \(x) min(diff(x))) |>
     unlist() |>
     min()
   if (min_diff < .Machine$double.eps * 10) {
@@ -68,7 +68,7 @@ adjust_resolution <- function(arg, f, unique = TRUE) {
 .adjust_resolution <- function(arg, resolution, unique = TRUE) {
   u <- if (unique) base::unique else function(x) x
   if (is.list(arg)) {
-    map(arg, ~ u(round_resolution(., resolution)))
+    map(arg, \(x) u(round_resolution(x, resolution)))
   } else {
     u(round_resolution(arg, resolution))
   }
@@ -93,7 +93,7 @@ is_equidist <- function(f) {
   }
   unique_diffs <- map_lgl(
     ensure_list(tf_arg(f)),
-    ~ round_resolution(.x, attr(f, "resolution")) |>
+    \(x) round_resolution(x, attr(f, "resolution")) |>
       diff() |>
       duplicated() |>
       tail(-1) |>
@@ -133,7 +133,7 @@ compare_tf_attribs <- function(e1, e2, ignore = c("names", "id")) {
       }
     )
   }
-  ret <- map(attribs, ~ .compare(a1[[.]], a2[[.]]))
+  ret <- map(attribs, \(x) .compare(a1[[x]], a2[[x]]))
   names(ret) <- attribs
   unlist(ret)
 }
@@ -169,7 +169,7 @@ get_args <- function(args, f) {
 #' Turns any object into a list
 #'
 #' See above.
-#' @param x any input 
+#' @param x any input
 #' @returns `x` turned into a list.
 #' @export
 #' @family tidyfun developer tools
@@ -180,7 +180,7 @@ ensure_list <- function(x) {
 #' Make syntactically valid unique names
 #'
 #' See above.
-#' @param x any input 
+#' @param x any input
 #' @returns `x` turned into a list.
 #' @export
 #' @family tidyfun developer tools

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -1,13 +1,13 @@
 c_names <- function(funs) {
   fnames <- as.list(names(funs) %||% rep("", length(funs)))
-  elnames <- map(funs, ~names(.x) %||% rep("", length(.x)))
+  elnames <- map(funs, \(x) names(x) %||% rep("", length(x)))
   # always use argnames
   # argnames replace elementnames if elments have length 1
   # else paste with "."
-  names <- map2(fnames, elnames, function(.x, .y) {
-    if (.x == "") return(.y)
-    if (all(.y == "") | length(.y) == 1) return(rep(.x, length(.y)))
-    paste(.x, .y, sep = ".")
+  names <- map2(fnames, elnames, \(x, y) {
+    if (x == "") return(y)
+    if (all(y == "") || length(y) == 1) return(rep(x, length(y)))
+    paste(x, y, sep = ".")
   }) |> unlist()
   if (all(names == "")) NULL else names
 }
@@ -61,7 +61,7 @@ vec_cast.tfd_reg.tfd_irreg <- function(x, to, ...) {
 vec_cast.tfd_irreg.tfd_reg <- function(x, to, ...) { 
   
   args <- attr(x, "arg")
-  cast_x <- tfd(map(.x = vctrs::vec_data(x), ~data.frame(arg = args, value = .x)))
+  cast_x <- tfd(map(vctrs::vec_data(x), \(x) data.frame(arg = args, value = x)))
   as.tfd_irreg.tfd_reg(cast_x)
   
 }
@@ -70,7 +70,7 @@ vec_cast.tfd_irreg.tfd_reg <- function(x, to, ...) {
 #' @family tidyfun vctrs
 #' @method vec_cast.tfd_irreg tfd_irreg
 #' @export
-vec_cast.tfd_irreg.tfd_irreg <- function(x, to, ...) { x }
+vec_cast.tfd_irreg.tfd_irreg <- function(x, to, ...) x
 
 
 
@@ -124,13 +124,10 @@ vec_ptype2.tfd_irreg.tfd_irreg <- function(x, y, ...) {vec_ptype2_tfd_tfd(x, y, 
 #' @family tidyfun vctrs
 #' @export
 vec_ptype2_tfd_tfd <- function(x, y, ...) {
-  
+
   funs <- list(x, y)
-  compatible <- do.call(rbind, map(
-    funs,
-    ~compare_tf_attribs(funs[[1]], .)
-  ))
-  
+  compatible <- do.call(rbind, map(funs, \(x) compare_tf_attribs(funs[[1]], x)))
+
   stopifnot(all(compatible[, "domain"]))
   make_irreg <- rep(FALSE, length(funs))
   irreg <- map_lgl(funs, is_irreg)
@@ -152,10 +149,7 @@ vec_ptype2_tfd_tfd <- function(x, y, ...) {
     make_irreg[!compatible[, "resolution"]] <- TRUE
   }
   if (any(make_irreg)) {
-    funs <- map_at(
-      funs, which(make_irreg),
-      ~as.tfd_irreg(.)
-    )
+    funs <- map_at(funs, which(make_irreg), as.tfd_irreg)
   }
   if (!all(compatible[, "evaluator_name"])) {
     warning(
@@ -288,17 +282,14 @@ vec_ptype2.tfb_fpc.tfb_fpc <- function(x, y, ...) {vec_ptype2_tfb_tfb(x, y, ...)
 #' @export
 vec_ptype2_tfb_tfb <- function(x, y, ...) {
   funs <- list(x, y)
-  compatible <- do.call(rbind, map(
-    funs,
-    ~compare_tf_attribs(funs[[1]], .)
-  ))
+  compatible <- do.call(rbind, map(funs, \(x) compare_tf_attribs(funs[[1]], x)))
   stopifnot(all(compatible[, "domain"]))
   
   if(inherits(funs[[1]], "tfb_spline")) {
     re_evals <- which(!compatible[, "arg"] |
                         !compatible[, "basis_args"])
     if (length(re_evals)) {
-      fun_names <- map(as.list(match.call())[-1], ~deparse(.)[1])
+      fun_names <- map(as.list(match.call())[-1], \(x) deparse(x)[1])
       warning(
         "re-evaluating ", paste(fun_names[re_evals], collapse = ", "),
         " using basis and arg of ", fun_names[1]
@@ -306,9 +297,9 @@ vec_ptype2_tfb_tfb <- function(x, y, ...) {
       
       funs <- map_at(
         funs, re_evals,
-        ~do.call(
+        \(x) do.call(
           tfb,
-          flatten(list(list(.), # converts to tfb then back to tfd
+          flatten(list(list(x), # converts to tfb then back to tfd
                        arg = list(tf_arg(funs[[1]])),
                        attr(funs[[1]], "basis_args")
           ))

--- a/R/where.R
+++ b/R/where.R
@@ -12,7 +12,7 @@
 #' of the usual `dplyr` tricks are available as well, see examples.\cr
 #' Any `cond`ition evaluates to `NA` on `NA`-entries in `f`.
 #'
-#' @param f a `tf` object  
+#' @param f a `tf` object
 #' @param cond a logical expression about `value` (and/or `arg`) that defines a condition about
 #'   the functions, see examples and details.
 #' @param return for each entry in `f`, `tf_where` either returns *all* `arg` for
@@ -29,34 +29,36 @@
 #'  - `return = "range"`: a data frame with columns "begin" and "end".
 #'  - else, a numeric vector of the same length as `f` with `NA` for entries of `f` that nowhere fulfill the `cond`ition.
 #' @examples
-#'   lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
-#'   tf_where(lin, value %inr% c(-1, .5))
-#'   tf_where(lin, value %inr% c(-1, .5), "range")
-#'   a <- 1
-#'   tf_where(lin, value > a, "first")
-#'   tf_where(lin, value < a, "last")
-#'   tf_where(lin, value > 2, "any")
-#'   tf_anywhere(lin, value > 2)
+#' lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
+#' tf_where(lin, value %inr% c(-1, .5))
+#' tf_where(lin, value %inr% c(-1, .5), "range")
+#' a <- 1
+#' tf_where(lin, value > a, "first")
+#' tf_where(lin, value < a, "last")
+#' tf_where(lin, value > 2, "any")
+#' tf_anywhere(lin, value > 2)
 #'
-#'   set.seed(4353)
-#'   f <- tf_rgp(5, 11L)
-#'   plot(f, pch = as.character(1:5), points = TRUE)
-#'   tf_where(f, value == max(value))
-#'   # where is the function increasing/decreasing?
-#'   tf_where(f, value > dplyr::lag(value, 1, value[1]))
-#'   tf_where(f, value < dplyr::lead(value, 1, tail(value, 1)))
-#'   # where are the (interior) extreme points (sign changes of `diff(value)`)?
-#'   tf_where(f, 
-#'     sign(c(diff(value)[1], diff(value))) !=
-#'       sign(c(diff(value), tail(diff(value), 1))))
-#'   # where in its second half is the function positive?
-#'   tf_where(f, arg > .5 & value > 0)
-#'   # does the function ever exceed?
-#'   tf_anywhere(f, value > 1)
+#' set.seed(4353)
+#' f <- tf_rgp(5, 11L)
+#' plot(f, pch = as.character(1:5), points = TRUE)
+#' tf_where(f, value == max(value))
+#' # where is the function increasing/decreasing?
+#' tf_where(f, value > dplyr::lag(value, 1, value[1]))
+#' tf_where(f, value < dplyr::lead(value, 1, tail(value, 1)))
+#' # where are the (interior) extreme points (sign changes of `diff(value)`)?
+#' tf_where(
+#'   f,
+#'   sign(c(diff(value)[1], diff(value))) !=
+#'     sign(c(diff(value), tail(diff(value), 1)))
+#' )
+#' # where in its second half is the function positive?
+#' tf_where(f, arg > .5 & value > 0)
+#' # does the function ever exceed?
+#' tf_anywhere(f, value > 1)
 #' @importFrom stats setNames
 #' @family tidyfun query-functions
 #' @export
-tf_where <- function(f, cond, 
+tf_where <- function(f, cond,
                      return = c("all", "first", "last", "range", "any"), arg) {
   if (missing(arg)) {
     arg <- tf_arg(f)
@@ -67,18 +69,15 @@ tf_where <- function(f, cond,
   parent <- parent.frame()
   where_at <- map(
     f[, arg, matrix = FALSE],
-    ~ subset(.x, eval(cond_call, envir = .x, enclos = parent))[["arg"]]
+    \(x) subset(x, eval(cond_call, envir = x, enclos = parent))[["arg"]]
   )
   where_at[is.na(f)] <- NA
-  
+
   if (return == "all") {
     return(where_at)
-  } 
-  
-  where_at <- 
-    map_if(where_at, 
-           ~ length(.x) == 0, 
-           ~{   NA  })
+  }
+
+  where_at <- map_if(where_at, \(x) length(x) == 0, \(x) NA)
   if (return == "range") {
     where_at <- map(where_at, range)
     where_at <- do.call(what = rbind, args = where_at) |>
@@ -87,7 +86,7 @@ tf_where <- function(f, cond,
     return(where_at)
   }
   where_at <- switch(return,
-    "any"   = map_lgl(where_at, ~ !all(is.na(.x))),
+    "any"   = map_lgl(where_at, \(x) !all(is.na(x))),
     "first" = map(where_at, min),
     "last"  = map(where_at, max)
   )
@@ -102,5 +101,3 @@ tf_anywhere <- function(f, cond, arg) {
   call$return <- "any"
   eval(call, parent.frame())
 }
-
-

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -14,11 +14,11 @@
 #' @family tidyfun utility functions
 #' @export
 #' @examples
-#'   (x <- tf_rgp(10))
-#'   plot(x)
-#'   tf_zoom(x, .5, .9)
-#'   lines(tf_zoom(x, .5, .9), col = "red")
-#'   points(tf_zoom(x, seq(0, .5, length.out = 10), seq(.5, 1, length.out = 10)), col = "blue")
+#' (x <- tf_rgp(10))
+#' plot(x)
+#' tf_zoom(x, .5, .9)
+#' lines(tf_zoom(x, .5, .9), col = "red")
+#' points(tf_zoom(x, seq(0, .5, length.out = 10), seq(.5, 1, length.out = 10)), col = "blue")
 tf_zoom <- function(f, begin, end, ...) {
   UseMethod("tf_zoom")
 }
@@ -45,20 +45,20 @@ prep_tf_zoom_args <- function(f, begin, end) {
 
 #' @rdname tf_zoom
 #' @export
-tf_zoom.tfd <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2], 
+tf_zoom.tfd <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2],
                         ...) {
   args <- prep_tf_zoom_args(f, begin, end)
   ret <- pmap(
     list(f[, tf_arg(f), matrix = FALSE], args$begin, args$end),
-    ~ subset(..1, arg >= ..2 & arg <= ..3)
+    \(x, y, z) subset(x, arg >= y & arg <= z)
   )
   if (is_irreg(f) || !args$regular) {
-    nas <- map_lgl(ret, ~length(.x$arg) == 0)
+    nas <- map_lgl(ret, \(x) length(x$arg) == 0)
     if (all(nas)) stop("no data in zoom region.")
     if (any(nas)) warning("NAs created by tf_zoom.")
     for (n in which(nas)) ret[[n]] <- data.frame(arg = unname(args$dom[1]), value = NA_real_)
   } else {
-    if (any(map_lgl(ret, ~length(.x$arg) == 0))) {
+    if (any(map_lgl(ret, \(x) length(x$arg) == 0))) {
       stop("no data in zoom region.")
     }
   }
@@ -69,7 +69,7 @@ tf_zoom.tfd <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2],
 
 #' @rdname tf_zoom
 #' @export
-tf_zoom.tfb <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2], 
+tf_zoom.tfb <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2],
                         ...) {
   args <- prep_tf_zoom_args(f, begin, end)
   if (!args$regular) {
@@ -87,8 +87,8 @@ tf_zoom.tfb <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2],
 
 #' @rdname tf_zoom
 #' @export
-tf_zoom.tfb_fpc <-  function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2], 
-                             ...) {
+tf_zoom.tfb_fpc <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2],
+                            ...) {
   warning("zoomed-in FPC representation likely to lose orthogonality of FPC basis.")
-  NextMethod()  
+  NextMethod()
 }

--- a/man/fpc_wsvd.Rd
+++ b/man/fpc_wsvd.Rd
@@ -38,9 +38,9 @@ package \code{mogsa} by Cheng Meng.
 }
 \seealso{
 Other tfb-class: 
+\code{\link{tfb}},
 \code{\link{tfb_fpc}()},
-\code{\link{tfb_spline}()},
-\code{\link{tfb}}
+\code{\link{tfb_spline}()}
 
 Other tfb_fpc-class: 
 \code{\link{tfb_fpc}()}

--- a/man/tf-package.Rd
+++ b/man/tf-package.Rd
@@ -36,7 +36,7 @@ Useful links:
 Authors:
 \itemize{
   \item Jeff Goldsmith
-  \item Julia Wrobel
+  \item Julia Wrobel (\href{https://orcid.org/0000-0001-6783-1421}{ORCID})
 }
 
 Other contributors:

--- a/man/tf_smooth.Rd
+++ b/man/tf_smooth.Rd
@@ -55,9 +55,9 @@ f_sg <- tf_smooth(f, "savgol", fl = 31)
 layout(t(1:4))
 plot(f, points = FALSE, main = "original")
 plot(f_lowess, points = FALSE, col = "blue", main = "lowess (default,\n span .9 in red)")
-lines(tf_smooth(f, "lowess", f = .9), col = "red", alpha= .2)
+lines(tf_smooth(f, "lowess", f = .9), col = "red", alpha = .2)
 plot(f_mean, points = FALSE, col = "blue", main = "rolling means &\n medians (red)")
-lines(f_median, col = "red", alpha= .2) # note constant extrapolation at both ends!
+lines(f_median, col = "red", alpha = .2) # note constant extrapolation at both ends!
 plot(f, points = FALSE, main = "orginal and\n savgol (red)")
 lines(f_sg, col = "red")
 }

--- a/man/tf_where.Rd
+++ b/man/tf_where.Rd
@@ -49,29 +49,31 @@ of the usual \code{dplyr} tricks are available as well, see examples.\cr
 Any \code{cond}ition evaluates to \code{NA} on \code{NA}-entries in \code{f}.
 }
 \examples{
-  lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
-  tf_where(lin, value \%inr\% c(-1, .5))
-  tf_where(lin, value \%inr\% c(-1, .5), "range")
-  a <- 1
-  tf_where(lin, value > a, "first")
-  tf_where(lin, value < a, "last")
-  tf_where(lin, value > 2, "any")
-  tf_anywhere(lin, value > 2)
+lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
+tf_where(lin, value \%inr\% c(-1, .5))
+tf_where(lin, value \%inr\% c(-1, .5), "range")
+a <- 1
+tf_where(lin, value > a, "first")
+tf_where(lin, value < a, "last")
+tf_where(lin, value > 2, "any")
+tf_anywhere(lin, value > 2)
 
-  set.seed(4353)
-  f <- tf_rgp(5, 11L)
-  plot(f, pch = as.character(1:5), points = TRUE)
-  tf_where(f, value == max(value))
-  # where is the function increasing/decreasing?
-  tf_where(f, value > dplyr::lag(value, 1, value[1]))
-  tf_where(f, value < dplyr::lead(value, 1, tail(value, 1)))
-  # where are the (interior) extreme points (sign changes of `diff(value)`)?
-  tf_where(f, 
-    sign(c(diff(value)[1], diff(value))) !=
-      sign(c(diff(value), tail(diff(value), 1))))
-  # where in its second half is the function positive?
-  tf_where(f, arg > .5 & value > 0)
-  # does the function ever exceed?
-  tf_anywhere(f, value > 1)
+set.seed(4353)
+f <- tf_rgp(5, 11L)
+plot(f, pch = as.character(1:5), points = TRUE)
+tf_where(f, value == max(value))
+# where is the function increasing/decreasing?
+tf_where(f, value > dplyr::lag(value, 1, value[1]))
+tf_where(f, value < dplyr::lead(value, 1, tail(value, 1)))
+# where are the (interior) extreme points (sign changes of `diff(value)`)?
+tf_where(
+  f,
+  sign(c(diff(value)[1], diff(value))) !=
+    sign(c(diff(value), tail(diff(value), 1)))
+)
+# where in its second half is the function positive?
+tf_where(f, arg > .5 & value > 0)
+# does the function ever exceed?
+tf_anywhere(f, value > 1)
 }
 \concept{tidyfun query-functions}

--- a/man/tf_zoom.Rd
+++ b/man/tf_zoom.Rd
@@ -35,11 +35,11 @@ be turned into irregular \code{tfd}-objects iff \code{begin} or \code{end} are n
 These are used to redefine or restrict the \code{domain} of \code{tf} objects.
 }
 \examples{
-  (x <- tf_rgp(10))
-  plot(x)
-  tf_zoom(x, .5, .9)
-  lines(tf_zoom(x, .5, .9), col = "red")
-  points(tf_zoom(x, seq(0, .5, length.out = 10), seq(.5, 1, length.out = 10)), col = "blue")
+(x <- tf_rgp(10))
+plot(x)
+tf_zoom(x, .5, .9)
+lines(tf_zoom(x, .5, .9), col = "red")
+points(tf_zoom(x, seq(0, .5, length.out = 10), seq(.5, 1, length.out = 10)), col = "blue")
 }
 \seealso{
 Other tidyfun utility functions: 

--- a/man/tfb_fpc.Rd
+++ b/man/tfb_fpc.Rd
@@ -123,8 +123,8 @@ tfb_fpc(data, method = fpca_sc_wrapper)
 
 Other tfb-class: 
 \code{\link{fpc_wsvd}()},
-\code{\link{tfb_spline}()},
-\code{\link{tfb}}
+\code{\link{tfb}},
+\code{\link{tfb_spline}()}
 
 Other tfb_fpc-class: 
 \code{\link{fpc_wsvd}()}

--- a/man/tfb_spline.Rd
+++ b/man/tfb_spline.Rd
@@ -186,8 +186,8 @@ at once might yield better results, this is \emph{not} what's implemented here.
 
 Other tfb-class: 
 \code{\link{fpc_wsvd}()},
-\code{\link{tfb_fpc}()},
-\code{\link{tfb}}
+\code{\link{tfb}},
+\code{\link{tfb_fpc}()}
 }
 \concept{tfb-class}
 \concept{tfb_spline-class}

--- a/man/tfbrackets.Rd
+++ b/man/tfbrackets.Rd
@@ -63,7 +63,8 @@ in between with \code{NAs}. This package was developed by fickle, irridescently
 rainbow-colored unicorns.
 }
 \examples{
-(x <- 1:3 * tfd(data = 0:10, arg = 0:10)); plot(x)
+(x <- 1:3 * tfd(data = 0:10, arg = 0:10))
+plot(x)
 # this operator's 2nd argument is quite overloaded -- you can:
 # 1. simply extract elements from the vector if no second arg is given:
 x[1]
@@ -71,10 +72,10 @@ x[c(TRUE, FALSE, FALSE)]
 x[-(2:3)]
 # 2. use the second argument and optional additional arguments to
 #    extract specific function evaluations in a number of formats:
-x[1:2 , c(4.5, 9)] #returns a matrix of function evaluations
-x[1:2 , c(4.5, 9), interpolate = FALSE] # NA for arg-values not in the original data
-x[-3 , seq(1, 9, by = 2), matrix = FALSE] #list of data.frames for each function
-# in order to evaluate a set of observed functions on a new grid and 
+x[1:2, c(4.5, 9)] # returns a matrix of function evaluations
+x[1:2, c(4.5, 9), interpolate = FALSE] # NA for arg-values not in the original data
+x[-3, seq(1, 9, by = 2), matrix = FALSE] # list of data.frames for each function
+# in order to evaluate a set of observed functions on a new grid and
 # save them as a functional data vector again, use `tfd` or `tfb` instead:
 tfd(x, arg = seq(0, 10, by = .01), resolution = 1e-3)
 }

--- a/man/tfd.Rd
+++ b/man/tfd.Rd
@@ -142,15 +142,15 @@ of 10: e.g., if the smallest difference between consecutive
 In code: \verb{resolution = 10^(floor(log10(min(diff(<arg>))) - 1)}
 }
 \examples{
-#turn irregular to regular tfd by evaluating on a common grid:
+# turn irregular to regular tfd by evaluating on a common grid:
 
 (f <- c(tf_rgp(1, arg = seq(0, 1, length.out = 11)), tf_rgp(1, arg = seq(0, 1, length.out = 21))))
 tfd(f, arg = seq(0, 1, length.out = 21))
 
 set.seed(1213)
 (f <- tf_rgp(3, arg = seq(0, 1, length.out = 51)) |> tf_sparsify(.9))
-#does not yield regular data because linear extrapolation yields NAs outside observed range:
-tfd(f, arg = seq(0, 1, length.out = 101)) 
+# does not yield regular data because linear extrapolation yields NAs outside observed range:
+tfd(f, arg = seq(0, 1, length.out = 101))
 # this "works" (but may not yield sensible values..!!) for e.g. constant extrapolation:
 tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, length.out = 101))
 plot(f, col = 2)


### PR DESCRIPTION
- Replace formula syntax w/ lambda functions in purrr calls
- Make use of `lengths` function and remove `vapply(x, length, numeric(1)` pattern
- Apply styler formatting to some files
- Replace vapply with purrr functions