### PR TITLE
refactor: replace stopifnot for checkmate

### DIFF
--- a/R/brackets.R
+++ b/R/brackets.R
@@ -45,7 +45,7 @@
 #' @aliases tfbrackets
 #' @family tidyfun bracket-operator
 #' @examples
-#' (x <- 1:3 * tfd(data = 0:10, arg = 0:10))
+#' x <- 1:3 * tfd(data = 0:10, arg = 0:10)
 #' plot(x)
 #' # this operator's 2nd argument is quite overloaded -- you can:
 #' # 1. simply extract elements from the vector if no second arg is given:
@@ -59,7 +59,7 @@
 #' x[-3, seq(1, 9, by = 2), matrix = FALSE] # list of data.frames for each function
 #' # in order to evaluate a set of observed functions on a new grid and
 #' # save them as a functional data vector again, use `tfd` or `tfb` instead:
-#' tfd(x, arg = seq(0, 10, by = .01), resolution = 1e-3)
+#' tfd(x, arg = seq(0, 10, by = 0.01), resolution = 1e-3)
 `[.tf` <- function(x, i, j, interpolate = TRUE, matrix = TRUE) {
   if (!interpolate && inherits(x, "tfb")) {
     interpolate <- TRUE

--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -3,7 +3,7 @@
 # replaces functionality of tf_unnest.tf
 # turn a tf object into a data.frame evaluated on arg with cols id-arg-value
 tf_2_df <- function(tf, arg, interpolate = TRUE, ...) {
-  stopifnot(inherits(tf, "tf"))
+  assert_class(tf, "tf")
   if (missing(arg)) {
     arg <- tf_arg(tf)
   }
@@ -11,7 +11,8 @@ tf_2_df <- function(tf, arg, interpolate = TRUE, ...) {
   assert_arg(arg, tf)
 
   tmp <- do.call(rbind,
-                 args = tf[, arg, matrix = FALSE, interpolate = interpolate])
+    args = tf[, arg, matrix = FALSE, interpolate = interpolate]
+  )
   n_evals <- lengths(arg)
   tmp$id <-
     if (length(n_evals) == 1) {
@@ -33,9 +34,10 @@ df_2_mat <- function(data, binning = FALSE, maxbins = 1000) {
   newid <- as.numeric(as.factor(data$id))
   bins <- sort(unique(data$arg))
   if (binning && (length(bins) > maxbins)) {
-    binvalues <- seq((1 - 0.001 * sign(bins[1])) * bins[1],
-                     (1 + 0.001 * sign(bins[length(bins)])) * bins[length(bins)],
-                     length.out = maxbins + 1
+    binvalues <- seq(
+      (1 - 0.001 * sign(bins[1])) * bins[1],
+      (1 + 0.001 * sign(bins[length(bins)])) * bins[length(bins)],
+      length.out = maxbins + 1
     )
     bins <- binvalues
     binvalues <- head(stats::filter(binvalues, c(0.5, 0.5)), -1)
@@ -78,7 +80,7 @@ mat_2_df <- function(x, arg) {
   stopifnot(
     is.numeric(x), is.matrix(x),
     is.numeric(arg), length(arg) == ncol(x)
-    )
+  )
 
   id <- unique_id(rownames(x)) %||% seq_len(dim(x)[1])
   id <- ordered(id, levels = unique(id))

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -17,9 +17,9 @@
 #' @examples
 #' f <- tf_rgp(3, arg = seq(0, 1, length.out = 11))
 #' tf_evaluate(f) |> str()
-#' tf_evaluate(f, arg = .5) |> str()
+#' tf_evaluate(f, arg = 0.5) |> str()
 #' # equivalent, as matrix:
-#' f[, .5]
+#' f[, 0.5]
 #' new_grid <- seq(0, 1, length.out = 6)
 #' tf_evaluate(f, arg = new_grid) |> str()
 #' # equivalent, as matrix:

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -111,7 +111,7 @@ plot.tf <- function(x, y, n_grid = 50, points = is_irreg(x),
 
 #' @importFrom graphics matlines
 linespoints_tf <- function(x, arg, n_grid = 50, points = TRUE,
-                           alpha = min(1, max(.05, 2 / length(x))),
+                           alpha = min(1, max(0.05, 2 / length(x))),
                            interpolate = TRUE, ...) {
   assert_number(n_grid, na.ok = TRUE)
   if (missing(arg)) {
@@ -140,7 +140,7 @@ linespoints_tf <- function(x, arg, n_grid = 50, points = TRUE,
 #' @rdname tfviz
 #' @family tidyfun visualization
 lines.tf <- function(x, arg, n_grid = 50,
-                     alpha = min(1, max(.05, 2 / length(x))), ...) {
+                     alpha = min(1, max(0.05, 2 / length(x))), ...) {
   args <- c(modifyList(
     head(formals(lines.tf), -1),
     as.list(match.call())[-1]
@@ -158,7 +158,7 @@ lines.tf <- function(x, arg, n_grid = 50,
 #'   for arg for which no original data is available? Only relevant for
 #'   tfd, defaults to FALSE
 points.tf <- function(x, arg, n_grid = NA,
-                      alpha = min(1, max(.05, 2 / length(x))),
+                      alpha = min(1, max(0.05, 2 / length(x))),
                       interpolate = FALSE, ...) {
   args <- c(modifyList(
     head(formals(points.tf), -1),

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -55,7 +55,7 @@ prep_plotting_arg <- function(f, n_grid) {
 #'   spaghetti plots. *Epidemiology (Cambridge, Mass.)*, **21**(5), 621-625.
 plot.tf <- function(x, y, n_grid = 50, points = is_irreg(x),
                     type = c("spaghetti", "lasagna"),
-                    alpha = min(1, max(.05, 2 / length(x))), ...) {
+                    alpha = min(1, max(0.05, 2 / length(x))), ...) {
   type <- match.arg(type)
   assert_logical(points)
   assert_number(n_grid, na.ok = TRUE)

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -29,14 +29,16 @@
 #' # filling out sparse data (use a suitable evaluator -function!)
 #' sparse <- tf_rgp(10, arg = seq(0, 5, length.out = 21))
 #' plot(sparse)
-#' tfd(sparse, evaluator= tf_approx_spline) |>   #change eval. for better interpolation
+#' # change evaluator for better interpolation
+#' tfd(sparse, evaluator = tf_approx_spline) |>
 #'   tf_interpolate(arg = seq(0, 5, length.out = 201)) |>
 #'   lines(col = 2)
 #'
 #' set.seed(1860)
-#' (sparse_irregular <- tf_rgp(5) |>  tf_sparsify(.5) |> tf_jiggle())
+#' sparse_irregular <- tf_rgp(5) |>
+#'   tf_sparsify(0.5) |>
+#'   tf_jiggle()
 #' tf_interpolate(sparse_irregular, arg = seq(0, 1, length.out = 51))
-#'
 tf_interpolate <- function(object, arg, ...) UseMethod("tf_interpolate")
 
 #' @export

--- a/R/methods.R
+++ b/R/methods.R
@@ -75,14 +75,14 @@ tf_count.tfd_reg <- function(f) length(tf_arg(f))
 #' @rdname tfmethods
 #' @export
 tf_domain <- function(f) {
-  stopifnot(inherits(f, "tf"))
+  assert_class(f, "tf")
   attr(f, "domain")
 }
 
 #' @rdname tfmethods
 #' @export
 `tf_domain<-` <- function(x, value) {
-  stopifnot(inherits(x, "tf"))
+  assert_class(x, "tf")
   assert_numeric(value, any.missing = FALSE, len = 2, unique = TRUE, sorted = TRUE)
   tf_zoom(f = x, begin = value[1], end = value[2])
 }
@@ -92,7 +92,7 @@ tf_domain <- function(f) {
 #' @rdname tfmethods
 #' @export
 tf_evaluator <- function(f) {
-  stopifnot(inherits(f, "tfd"))
+  assert_class(f, "tfd")
   attr(f, "evaluator")
 }
 
@@ -113,7 +113,7 @@ tf_evaluator <- function(f) {
   }
   stopifnot(is_tfd(x))
   evaluator <- get(value, mode = "function", envir = parent.frame())
-  stopifnot(inherits(x, "tfd"))
+  assert_class(x, "tfd")
   assert_set_equal(
     names(formals(evaluator)),
     c("x", "arg", "evaluations")
@@ -130,7 +130,7 @@ tf_evaluator <- function(f) {
 #'   `tf_arg(f)`? Defaults to FALSE.
 #' @export
 tf_basis <- function(f, as_tfd = FALSE) {
-  stopifnot(inherits(f, "tfb"))
+  assert_class(f, "tfb")
   basis <- attr(f, "basis")
   if (!as_tfd) {
     return(basis)

--- a/R/ops.R
+++ b/R/ops.R
@@ -172,7 +172,7 @@ Ops.tfb <- function(e1, e2) {
       if (.Generic == "^") {
         stop("^ not defined for \"tfb\" objects")
       }
-      stopifnot(compare_tf_attribs(e1, e2))
+      stopifnot(all(compare_tf_attribs(e1, e2)))
     }
     if (both_funs && .Generic %in% c("+", "-")) {
       # just add/subtract coefs for identical bases

--- a/R/ops.R
+++ b/R/ops.R
@@ -172,7 +172,7 @@ Ops.tfb <- function(e1, e2) {
       if (.Generic == "^") {
         stop("^ not defined for \"tfb\" objects")
       }
-      stopifnot(all(compare_tf_attribs(e1, e2)))
+      stopifnot(compare_tf_attribs(e1, e2))
     }
     if (both_funs && .Generic %in% c("+", "-")) {
       # just add/subtract coefs for identical bases

--- a/R/ops.R
+++ b/R/ops.R
@@ -45,7 +45,7 @@ fun_op <- function(x, y, op, numeric = NA) {
     }
   }
   attributes(ret) <- attr_ret
-  if (any(is.na(names(ret)))) {
+  if (anyNA(names(ret))) {
     names(ret) <- NULL
   }
   ret
@@ -123,7 +123,7 @@ Ops.tf <- function(e1, e2) {
 
 #' @rdname tfgroupgenerics
 #' @export
-`!=.tfd` <- function(e1, e2) !(e1 == e2)
+`!=.tfd` <- function(e1, e2) e1 != e2
 
 # need to copy instead of defining tf-method s.t. dispatch in Ops works
 #' @rdname tfgroupgenerics

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -32,7 +32,7 @@ string_rep_tf <- function(f, signif_arg = NULL,
   str <- pmap(
     list(str, arg_len, show), \(x, y, z) ifelse(y > z, paste0(x, "; ..."), x)
   )
-  map_if(str, grepl("NA\\)", str), \(x) "NA")
+  map_if(str, grepl("NA)", str, fixed = TRUE), \(x) "NA")
 }
 
 #-------------------------------------------------------------------------------

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -117,7 +117,7 @@ format.tf <- function(x, digits = 2, nsmall = 0, width = options()$width,
     digits = digits, nsmall = nsmall, ...
   )
   if (prefix) {
-    prefix <- if (!all(names(x) == "")) {
+    prefix <- if (!all(nzchar(names(x), keepNA = TRUE))) {
       names(x)[seq_along(str)]
     } else {
       paste0("[", seq_along(str), "]")

--- a/R/rng.R
+++ b/R/rng.R
@@ -84,9 +84,9 @@ tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"),
 #' @export
 #' @rdname tf_jiggle
 #' @family tidyfun RNG functions
-tf_jiggle <- function(f, amount = .4, ...) {
+tf_jiggle <- function(f, amount = 0.4, ...) {
   stopifnot(is_tfd(f))
-  assert_number(amount, lower = 0, upper = .5)
+  assert_number(amount, lower = 0, upper = 0.5)
   f <- as.tfd_irreg(f)
   new_args <- map(tf_arg(f), tf_jiggle_args, amount = amount)
   tfd(map2(new_args, tf_evaluations(f), cbind), domain = tf_domain(f))
@@ -115,7 +115,7 @@ tf_jiggle_args <- function(arg, amount) {
 #' @param ... not used currently
 #' @export
 #' @family tidyfun RNG functions
-tf_sparsify <- function(f, dropout = .5, ...) {
+tf_sparsify <- function(f, dropout = 0.5, ...) {
   stopifnot(is_tf(f))
   nas <- map(
     tf_evaluations(f), \(x) ifelse(runif(length(x)) < dropout, TRUE, FALSE)

--- a/R/rng.R
+++ b/R/rng.R
@@ -117,9 +117,7 @@ tf_jiggle_args <- function(arg, amount) {
 #' @family tidyfun RNG functions
 tf_sparsify <- function(f, dropout = 0.5, ...) {
   stopifnot(is_tf(f))
-  nas <- map(
-    tf_evaluations(f), \(x) ifelse(runif(length(x)) < dropout, TRUE, FALSE)
-  )
+  nas <- map(tf_evaluations(f), \(x) runif(length(x)) < dropout)
   tf_evals <- map2(tf_evaluations(f), nas, \(x, y) x[!y])
   tf_args <- ensure_list(tf_arg(f))
   tf_args <- map2(tf_args, nas, \(x, y) x[!y])

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -7,7 +7,7 @@
 #' @details `tf_smooth.tfd` overrides/automatically sets some defaults of the
 #'   used methods:
 #'
-#'   - **`lowess`** uses a span parameter of `f` = .15 (instead of .75)
+#'   - **`lowess`** uses a span parameter of `f` = 0.15 (instead of 0.75)
 #'   by default.
 #'   - **`rollmean`/`median`** use a window size of `k` = $<$number of
 #'   grid points$>$/20 (i.e., the nearest odd integer to that) and sets `fill=
@@ -49,7 +49,7 @@ tf_smooth.tfb <- function(x, ...) {
 #' @examples
 #' library(zoo)
 #' library(pracma)
-#' f <- tf_sparsify(tf_jiggle(tf_rgp(4, 201L, nugget = .05)))
+#' f <- tf_sparsify(tf_jiggle(tf_rgp(4, 201, nugget = 0.05)))
 #' f_lowess <- tf_smooth(f, "lowess")
 #' # these methods ignore the distances between arg-values:
 #' f_mean <- tf_smooth(f, "rollmean")
@@ -57,10 +57,14 @@ tf_smooth.tfb <- function(x, ...) {
 #' f_sg <- tf_smooth(f, "savgol", fl = 31)
 #' layout(t(1:4))
 #' plot(f, points = FALSE, main = "original")
-#' plot(f_lowess, points = FALSE, col = "blue", main = "lowess (default,\n span .9 in red)")
-#' lines(tf_smooth(f, "lowess", f = .9), col = "red", alpha = .2)
-#' plot(f_mean, points = FALSE, col = "blue", main = "rolling means &\n medians (red)")
-#' lines(f_median, col = "red", alpha = .2) # note constant extrapolation at both ends!
+#' plot(f_lowess,
+#'   points = FALSE, col = "blue", main = "lowess (default,\n span 0.9 in red)"
+#' )
+#' lines(tf_smooth(f, "lowess", f = 0.9), col = "red", alpha = 0.2)
+#' plot(f_mean,
+#'   points = FALSE, col = "blue", main = "rolling means &\n medians (red)"
+#' )
+#' lines(f_median, col = "red", alpha = 0.2) # note constant extrapolation at both ends!
 #' plot(f, points = FALSE, main = "orginal and\n savgol (red)")
 #' lines(f_sg, col = "red")
 tf_smooth.tfd <- function(x,
@@ -78,7 +82,7 @@ tf_smooth.tfd <- function(x,
     }
     if (grepl("rollm", method)) {
       if (is.null(dots$k)) {
-        dots$k <- ceiling(.05 * min(tf_count(x)))
+        dots$k <- ceiling(0.05 * min(tf_count(x)))
         dots$k <- dots$k + !(dots$k %% 2) # make uneven
         message(
           "using k = ", dots$k, " observations for rolling data window."
@@ -91,7 +95,7 @@ tf_smooth.tfd <- function(x,
     }
     if (method == "savgol") {
       if (is.null(dots$fl)) {
-        dots$fl <- ceiling(.15 * min(tf_count(x)))
+        dots$fl <- ceiling(0.15 * min(tf_count(x)))
         dots$fl <- dots$fl + !(dots$fl %% 2) # make uneven
         message(
           "using fl = ", dots$fl, " observations for rolling data window."
@@ -106,7 +110,7 @@ tf_smooth.tfd <- function(x,
 
   if (method == "lowess") {
     if (is.null(dots$f)) {
-      dots$f <- .15
+      dots$f <- 0.15
       message("using f = ", dots$f, " as smoother span for lowess")
     }
     smoothed <- map(

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -80,7 +80,7 @@ tf_smooth.tfd <- function(x,
         " ignored by ", method, "."
       )
     }
-    if (grepl("rollm", method)) {
+    if (grepl("rollm", method, fixed = TRUE)) {
       if (is.null(dots$k)) {
         dots$k <- ceiling(0.05 * min(tf_count(x)))
         dots$k <- dots$k + !(dots$k %% 2) # make uneven

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -26,7 +26,7 @@ mean.tf <- function(x, ...) {
 #' @rdname tfsummaries
 median.tf <- function(x, na.rm = FALSE, depth = c("MBD", "pointwise"), ...) {
   if (!na.rm) {
-    if (any(is.na(x))) return(1 * NA * x[1])
+    if (anyNA(x)) return(1 * NA * x[1])
   } else {
     x <- x[!is.na(x)]
   }

--- a/R/tfb-fpc-utils.R
+++ b/R/tfb-fpc-utils.R
@@ -16,13 +16,14 @@
 #' @author Cheng Meng, Fabian Scheipl
 #' @family tfb-class
 #' @family tfb_fpc-class
-fpc_wsvd <- function(data, arg, pve = .995) {
+fpc_wsvd <- function(data, arg, pve = 0.995) {
   UseMethod("fpc_wsvd")
 }
+
 #' @rdname fpc_wsvd
 #' @importFrom utils head tail
 #' @export
-fpc_wsvd.matrix <- function(data, arg, pve = .995) {
+fpc_wsvd.matrix <- function(data, arg, pve = 0.995) {
   assert_matrix(data, mode = "numeric", any.missing = FALSE,
                 min.cols = 2, min.rows = 1)
   assert_numeric(arg, any.missing = FALSE, sorted = TRUE, len = ncol(data))
@@ -30,7 +31,7 @@ fpc_wsvd.matrix <- function(data, arg, pve = .995) {
 
   delta <- c(0, diff(arg))
   # trapezoid integration weights:
-  w <- .5 * c(delta[-1] + head(delta, -1), tail(delta, 1))
+  w <- 0.5 * c(delta[-1] + head(delta, -1), tail(delta, 1))
   mean <- colMeans(data)
   data_wc <- t((t(data) - mean) * sqrt(w))
   pc <- svd(data_wc, nu = 0, nv = min(dim(data)))
@@ -44,9 +45,10 @@ fpc_wsvd.matrix <- function(data, arg, pve = .995) {
     scores = scores, npc = use, evalues = evalues
   )
 }
+
 #' @rdname fpc_wsvd
 #' @export
-fpc_wsvd.data.frame <- function(data, arg, pve = .995) {
+fpc_wsvd.data.frame <- function(data, arg, pve = 0.995) {
   data_mat <- df_2_mat(data)
   fpc_wsvd.matrix(data_mat, arg = attr(data_mat, "arg"), pve = pve)
 }

--- a/R/tfb-fpc.R
+++ b/R/tfb-fpc.R
@@ -76,7 +76,7 @@ new_tfb_fpc <- function(data, domain = NULL, resolution = NULL,
 #' @param ... arguments to the `method` which computes the
 #'  (regularized/smoothed) FPCA.
 #'  Unless set by the user, uses proportion of variance explained
-#'  `pve = .995` to determine the truncation levels.
+#'  `pve = 0.995` to determine the truncation levels.
 #' @inheritParams tfb
 #' @returns an object of class `tfb_fpc`, inheriting from `tfb`.
 #'    The basis used by `tfb_fpc` is a `tfd`-vector containing the estimated
@@ -95,16 +95,17 @@ tfb_fpc <- function(data, ...) UseMethod("tfb_fpc")
 #' # Apply FPCA for sparse data using refund::fpca.sc:
 #' set.seed(99290)
 #' # create sparse data:
-#' data <- tf_rgp(15) |> tf_sparsify() |> as.data.frame(unnest = TRUE)
+#' data <- tf_rgp(15) |>
+#'   tf_sparsify() |>
+#'   as.data.frame(unnest = TRUE)
 #' # wrap refund::fpca_sc for use as FPCA method in tfb_fpc:
-#' fpca_sc_wrapper <- function(data, arg, pve = .995, ...) {
+#' fpca_sc_wrapper <- function(data, arg, pve = 0.995, ...) {
 #'   data_mat <- tf:::df_2_mat(data)
-#'   fpca <- refund::fpca.sc(Y = data_mat,
-#'                           argvals = attr(data_mat, "arg"),
-#'                           pve = pve, ...)
+#'   fpca <- refund::fpca.sc(
+#'     Y = data_mat, argvals = attr(data_mat, "arg"), pve = pve, ...
+#'   )
 #'   fpca[c("mu", "efunctions", "scores", "npc")]
 #' }
-#' tfb_fpc(data, method = fpca_sc_wrapper)
 tfb_fpc.data.frame <- function(data, id = 1, arg = 2, value = 3,
                                domain = NULL, method = fpc_wsvd,
                                resolution = NULL, ...) {

--- a/R/tfb-spline-utils.R
+++ b/R/tfb-spline-utils.R
@@ -216,7 +216,7 @@ fit_ml <- function(data, spec_object, gam_args, arg_u, penalized, sp = -1) {
   if (length(failed) > 0) {
     stop(
       "Basis representation failed for entries:\n ",
-      paste(unname(failed), collapse = ", ")
+      toString(unname(failed))
     )
   }
   list(

--- a/R/tfb-spline-utils.R
+++ b/R/tfb-spline-utils.R
@@ -212,7 +212,7 @@ fit_ml <- function(data, spec_object, gam_args, arg_u, penalized, sp = -1) {
   )
   names(ret) <- levels(data$id)
   coef <- map(ret, "coef")
-  failed <- keep(coef, \(x) any(is.na(x)))
+  failed <- keep(coef, anyNA)
   if (length(failed) > 0) {
     stop(
       "Basis representation failed for entries:\n ",

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -257,7 +257,7 @@ tfb_spline.list <- function(data, arg = NULL,
   }
   dims <- map(data, dim)
   stopifnot(
-    all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2] == 2)),
+    all(lengths(dims) == 2), all(map_int(dims, 2) == 2),
     all(rapply(data, is.numeric))
   )
   n_evals <- map(dims, 1)

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -237,7 +237,7 @@ tfb_spline.list <- function(data, arg = NULL,
                             domain = NULL, penalized = TRUE,
                             global = FALSE, resolution = NULL, ...) {
   vectors <- map_lgl(data, is.numeric)
-  stopifnot(all(vectors | !any(vectors)))
+  stopifnot(all(vectors) | !any(vectors))
 
   names_data <- names(data)
 

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -237,7 +237,7 @@ tfb_spline.list <- function(data, arg = NULL,
                             domain = NULL, penalized = TRUE,
                             global = FALSE, resolution = NULL, ...) {
   vectors <- map_lgl(data, is.numeric)
-  stopifnot(vectors | !any(vectors))
+  stopifnot(all(vectors | !any(vectors)))
 
   names_data <- names(data)
 
@@ -250,7 +250,8 @@ tfb_spline.list <- function(data, arg = NULL,
                  global = global, resolution = resolution, ...))
     }
     stopifnot(
-      !is.null(arg), length(arg) == length(data), lengths(arg) == lens
+      !is.null(arg), length(arg) == length(data),
+      all(lengths(arg) == lens)
     )
     data <- map2(arg, data, \(x, y) as.data.frame(cbind(arg = x, value = y)))
   }

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -257,7 +257,7 @@ tfb_spline.list <- function(data, arg = NULL,
   }
   dims <- map(data, dim)
   stopifnot(
-    all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2]) == 2),
+    all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2] == 2)),
     all(rapply(data, is.numeric))
   )
   n_evals <- map(dims, 1)

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -237,7 +237,7 @@ tfb_spline.list <- function(data, arg = NULL,
                             domain = NULL, penalized = TRUE,
                             global = FALSE, resolution = NULL, ...) {
   vectors <- map_lgl(data, is.numeric)
-  stopifnot(all(vectors) | !any(vectors))
+  stopifnot(vectors | !any(vectors))
 
   names_data <- names(data)
 

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -256,7 +256,7 @@ tfb_spline.list <- function(data, arg = NULL,
   }
   dims <- map(data, dim)
   stopifnot(
-    all(lengths(dims) == 2), all(map(dims, \(x) x[2]) == 2),
+    all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2]) == 2),
     all(rapply(data, is.numeric))
   )
   n_evals <- map(dims, 1)

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -250,8 +250,7 @@ tfb_spline.list <- function(data, arg = NULL,
                  global = global, resolution = resolution, ...))
     }
     stopifnot(
-      !is.null(arg), length(arg) == length(data),
-      all(lengths(arg) == lens)
+      !is.null(arg), length(arg) == length(data), lengths(arg) == lens
     )
     data <- map2(arg, data, \(x, y) as.data.frame(cbind(arg = x, value = y)))
   }

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -237,7 +237,7 @@ tfd.list <- function(data, arg = NULL, domain = NULL,
   if (!any(vectors)) {
     dims <- map(data, dim)
     stopifnot(
-      all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2] == 2)),
+      all(lengths(dims) == 2), all(map_int(dims, 2) == 2),
       all(rapply(data, is.numeric))
     )
     arg <- map(data, \(x) unlist(x[, 1]))

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -237,7 +237,7 @@ tfd.list <- function(data, arg = NULL, domain = NULL,
   if (!any(vectors)) {
     dims <- map(data, dim)
     stopifnot(
-      all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2]) == 2),
+      all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2] == 2)),
       all(rapply(data, is.numeric))
     )
     arg <- map(data, \(x) unlist(x[, 1]))

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -155,7 +155,7 @@ tfd.matrix <- function(data, arg = NULL, domain = NULL,
   # make factor conversion explicit to avoid reordering
   datalist <- split(data, factor(id, unique(as.character(id))))
   names(datalist) <- rownames(data)
-  regular <- !any(is.na(data))
+  regular <- !anyNA(data)
   new_tfd(arg, datalist, regular, domain, evaluator, resolution)
 }
 
@@ -237,7 +237,7 @@ tfd.list <- function(data, arg = NULL, domain = NULL,
   if (!any(vectors)) {
     dims <- map(data, dim)
     stopifnot(
-      all(lengths(dims) == 2), all(map(dims, \(x) x[2]) == 2),
+      all(lengths(dims) == 2), all(map_lgl(dims, \(x) x[2]) == 2),
       all(rapply(data, is.numeric))
     )
     arg <- map(data, \(x) unlist(x[, 1]))

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -146,7 +146,7 @@ tfd <- function(data, ...) UseMethod("tfd")
 #' @importFrom rlang quo_name enexpr
 tfd.matrix <- function(data, arg = NULL, domain = NULL,
                        evaluator = tf_approx_linear, resolution = NULL, ...) {
-  stopifnot(is.numeric(data))
+  assert_numeric(data)
   evaluator <- rlang::quo_name(rlang::enexpr(evaluator))
   arg <- find_arg(data, arg) # either arg or numeric colnames or 1:ncol
   id <- unique_id(rownames(data) %||% seq_len(dim(data)[1]))
@@ -156,6 +156,7 @@ tfd.matrix <- function(data, arg = NULL, domain = NULL,
   regular <- !any(is.na(data))
   new_tfd(arg, datalist, regular, domain, evaluator, resolution)
 }
+
 #' @rdname tfd
 #' @export
 tfd.numeric <- function(data, arg = NULL,
@@ -341,6 +342,7 @@ as.tfd_irreg.tfd_reg <- function(data, ...) {
   class(ret)[1] <- "tfd_irreg"
   ret
 }
+
 #' @export
 as.tfd_irreg.tfd_irreg <- function(data, ...) {
   data

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -1,9 +1,9 @@
 #' @import purrr
 new_tfd <- function(arg = NULL, datalist = NULL, regular = TRUE,
                     domain = NULL, evaluator, resolution = NULL) {
-  #FIXME: names weirdness- tfd  objects will ALWAYS be named if they were
-  #created from an (intermediate) data.frame, but may be unnamed for different
-  #provenance....
+  # FIXME: names weirdness- tfd  objects will ALWAYS be named if they were
+  # created from an (intermediate) data.frame, but may be unnamed for different
+  # provenance....
   if (vctrs::vec_size(datalist) == 0) {
     subclass <- ifelse(regular, "tfd_reg", "tfd_irreg")
 
@@ -36,8 +36,10 @@ new_tfd <- function(arg = NULL, datalist = NULL, regular = TRUE,
   resolution <- resolution %||% get_resolution(arg)
 
   assert_number(resolution, lower = .Machine$double.eps, finite = TRUE)
-  assert_numeric(domain, finite = TRUE, any.missing = FALSE,
-                 sorted = TRUE, len = 2, unique = TRUE)
+  assert_numeric(domain,
+    finite = TRUE, any.missing = FALSE,
+    sorted = TRUE, len = 2, unique = TRUE
+  )
   stopifnot(
     domain[1] <= min(unlist(arg)),
     domain[2] >= max(unlist(arg))
@@ -109,7 +111,7 @@ new_tfd <- function(arg = NULL, datalist = NULL, regular = TRUE,
 #' **`resolution`**: `arg`-values that are equivalent up to this difference are
 #' treated as identical. E.g., if an evaluation of \eqn{f(t)} is available at
 #' \eqn{t=1} and a function value is requested at \eqn{t = 1.01}, \eqn{f(1)}
-#' will be returned if `resolution` < .01. By default, resolution will be set to
+#' will be returned if `resolution` < 0.01. By default, resolution will be set to
 #' an integer-valued power of 10 one smaller than the smallest difference
 #' between adjacent `arg`-values rounded down to an integer-valued power of 10:
 #' e.g., if the smallest difference between consecutive `arg`-values is between
@@ -252,15 +254,14 @@ tfd.list <- function(data, arg = NULL, domain = NULL,
 #' @examples
 #' # turn irregular to regular tfd by evaluating on a common grid:
 #'
-#' (f <- c(
+#' f <- c(
 #'   tf_rgp(1, arg = seq(0, 1, length.out = 11)),
 #'   tf_rgp(1, arg = seq(0, 1, length.out = 21))
-#'   ))
+#' )
 #' tfd(f, arg = seq(0, 1, length.out = 21))
 #'
 #' set.seed(1213)
-#' (f <- tf_rgp(3, arg = seq(0, 1, length.out = 51)) |>
-#'   tf_sparsify(.9))
+#' f <- tf_rgp(3, arg = seq(0, 1, length.out = 51)) |> tf_sparsify(0.9)
 #' # does not yield regular data because linear extrapolation yields NAs
 #' #   outside observed range:
 #' tfd(f, arg = seq(0, 1, length.out = 101))
@@ -268,8 +269,9 @@ tfd.list <- function(data, arg = NULL, domain = NULL,
 #' #   e.g. constant extrapolation:
 #' tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, length.out = 101))
 #' plot(f, col = 2)
-#' tfd(f, arg = seq(0, 1, length.out = 151),
-#'     evaluator = tf_approx_fill_extend) |>  lines()
+#' tfd(f,
+#'   arg = seq(0, 1, length.out = 151), evaluator = tf_approx_fill_extend
+#' ) |> lines()
 #' @rdname tfd
 tfd.tf <- function(data, arg = NULL, domain = NULL,
                    evaluator = NULL, resolution = NULL, ...) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,11 +97,13 @@ is_equidist <- function(f) {
   }
   unique_diffs <- map_lgl(
     ensure_list(tf_arg(f)),
-    \(x) round_resolution(x, attr(f, "resolution")) |>
-      diff() |>
-      duplicated() |>
-      tail(-1) |>
-      all()
+    \(x) {
+      round_resolution(x, attr(f, "resolution")) |>
+        diff() |>
+        duplicated() |>
+        tail(-1) |>
+        all()
+    }
   )
   all(unique_diffs)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ assert_arg <- function(arg, x, check_unique = TRUE) {
 .assert_arg_vector <- function(arg, domain_x, resolution_x, check_unique) {
   if (check_unique) {
     round_arg <- round_resolution(arg, resolution_x)
-    if (anyDuplicated(round_arg)) {
+    if (anyDuplicated(round_arg) == 0) {
       stop("Non-unique arg-values (for resolution).")
     }
   }
@@ -192,7 +192,7 @@ ensure_list <- function(x) {
 #' @family tidyfun developer tools
 # export for tidyfun...
 unique_id <- function(x) {
-  if (!anyDuplicated(x)) {
+  if (anyDuplicated(x) > 0) {
     return(x)
   }
   if (is.character(x)) x <- sub("$^", "NA", x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ assert_arg <- function(arg, x, check_unique = TRUE) {
 .assert_arg_vector <- function(arg, domain_x, resolution_x, check_unique) {
   if (check_unique) {
     round_arg <- round_resolution(arg, resolution_x)
-    if (anyDuplicated(round_arg) == 0) {
+    if (anyDuplicated(round_arg) > 0) {
       stop("Non-unique arg-values (for resolution).")
     }
   }
@@ -192,7 +192,7 @@ ensure_list <- function(x) {
 #' @family tidyfun developer tools
 # export for tidyfun...
 unique_id <- function(x) {
-  if (anyDuplicated(x) > 0) {
+  if (anyDuplicated(x) == 0) {
     return(x)
   }
   if (is.character(x)) x <- sub("$^", "NA", x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,13 +83,11 @@ adjust_resolution <- function(arg, f, unique = TRUE) {
 # "quantize" the values in arg to the given resolution
 round_resolution <- function(arg, resolution, updown = 0) {
   if (updown == 0) {
-    return(round(arg / resolution) * resolution)
-  }
-  if (updown < 0) {
-    return(floor(arg / resolution) * resolution)
-  }
-  if (updown > 0) {
-    return(ceiling(arg / resolution) * resolution)
+    round(arg / resolution) * resolution
+  } else if (updown < 0) {
+    floor(arg / resolution) * resolution
+  } else {
+    ceiling(arg / resolution) * resolution
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@ find_arg <- function(data, arg) {
   if (is.null(arg)) {
     names <- dimnames(data)[[2]]
     suppressWarnings(arg <- as.numeric(names))
-    if (is.null(arg) || any(is.na(arg))) {
+    if (is.null(arg) || anyNA(arg)) {
       # extract number-strings
       # will interpret separating-dashes as minus-signs, so functions may run
       # backwards.
@@ -17,7 +17,7 @@ find_arg <- function(data, arg) {
       suppressWarnings(arg <- as.numeric(arg))
       if (length(unique(arg)) != dim(data)[2]) arg <- NULL
     }
-    if (is.null(arg) || any(is.na(arg))) {
+    if (is.null(arg) || anyNA(arg)) {
       message("Column names not suitable as 'arg'-values. Using 1:ncol(data).")
       arg <- numeric(0)
     }

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -5,12 +5,12 @@ c_names <- function(funs) {
   # argnames replace elementnames if elments have length 1
   # else paste with "."
   names <- map2(fnames, elnames, \(x, y) {
-    if (x == "") return(y)
-    if (all(y == "") || length(y) == 1) return(rep(x, length(y)))
+    if (nzchar(x, keepNA = TRUE)) return(y)
+    if (all(nzchar(y, keepNA = TRUE)) || length(y) == 1) return(rep(x, length(y)))
     paste(x, y, sep = ".")
   }) |>
     unlist()
-  if (all(names == "")) NULL else names
+  if (all(nzchar(names, keepNA = TRUE))) NULL else names
 }
 
 
@@ -174,7 +174,7 @@ vec_ptype2_tfd_tfd <- function(x, y, ...) {
       funs,
       function(x) names(x) %||% rep("", length(x))
     )))
-    if (all(tmp == "")) NULL else tmp
+    if (all(nzchar(tmp, keepNA = TRUE))) NULL else tmp
   }
   ret <- flatten(funs)
   attributes(ret) <- attr_ret
@@ -347,7 +347,7 @@ vec_ptype2_tfb_tfb <- function(x, y, ...) {
       funs,
       function(x) names(x) %||% rep("", length(x))
     )))
-    if (all(tmp == "")) NULL else tmp
+    if (all(nzchar(tmp, keepNA = TRUE))) NULL else tmp
   }
   ret <- flatten(funs)
   attributes(ret) <- attr_ret

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -42,7 +42,7 @@ vec_cast.tfd_irreg <- function(x, to, ...) UseMethod("vec_cast.tfd_irreg")
 #' @family tidyfun vctrs
 #' @method vec_cast.tfd_reg tfd_reg
 #' @export
-vec_cast.tfd_reg.tfd_reg <- function(x, to, ...) { x }
+vec_cast.tfd_reg.tfd_reg <- function(x, to, ...) x
 
 #' @rdname vctrs
 #' @family tidyfun vctrs

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -310,7 +310,7 @@ vec_ptype2_tfb_tfb <- function(x, y, ...) {
     if (length(re_evals)) {
       fun_names <- map(as.list(match.call())[-1], \(x) deparse(x)[1])
       warning(
-        "re-evaluating ", paste(fun_names[re_evals], collapse = ", "),
+        "re-evaluating ", toString(fun_names[re_evals]),
         " using basis and arg of ", fun_names[1]
       )
 

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -136,7 +136,7 @@ vec_ptype2_tfd_tfd <- function(x, y, ...) {
   funs <- list(x, y)
   compatible <- do.call(rbind, map(funs, \(x) compare_tf_attribs(funs[[1]], x)))
 
-  stopifnot(all(compatible[, "domain"]))
+  stopifnot(compatible[, "domain"])
   make_irreg <- rep(FALSE, length(funs))
   irreg <- map_lgl(funs, is_irreg)
   if (!any(irreg) && !all(compatible[, "arg"])) {
@@ -301,7 +301,7 @@ vec_ptype2.tfb_fpc.tfb_fpc <- function(x, y, ...) {
 vec_ptype2_tfb_tfb <- function(x, y, ...) {
   funs <- list(x, y)
   compatible <- do.call(rbind, map(funs, \(x) compare_tf_attribs(funs[[1]], x)))
-  stopifnot(all(compatible[, "domain"]))
+  stopifnot(compatible[, "domain"])
 
   if (inherits(funs[[1]], "tfb_spline")) {
     re_evals <- which(

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -136,7 +136,7 @@ vec_ptype2_tfd_tfd <- function(x, y, ...) {
   funs <- list(x, y)
   compatible <- do.call(rbind, map(funs, \(x) compare_tf_attribs(funs[[1]], x)))
 
-  stopifnot(compatible[, "domain"])
+  stopifnot(all(compatible[, "domain"]))
   make_irreg <- rep(FALSE, length(funs))
   irreg <- map_lgl(funs, is_irreg)
   if (!any(irreg) && !all(compatible[, "arg"])) {
@@ -301,7 +301,7 @@ vec_ptype2.tfb_fpc.tfb_fpc <- function(x, y, ...) {
 vec_ptype2_tfb_tfb <- function(x, y, ...) {
   funs <- list(x, y)
   compatible <- do.call(rbind, map(funs, \(x) compare_tf_attribs(funs[[1]], x)))
-  stopifnot(compatible[, "domain"])
+  stopifnot(all(compatible[, "domain"]))
 
   if (inherits(funs[[1]], "tfb_spline")) {
     re_evals <- which(

--- a/R/where.R
+++ b/R/where.R
@@ -32,8 +32,8 @@
 #'   `f` that nowhere fulfill the `cond`ition.
 #' @examples
 #' lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
-#' tf_where(lin, value %inr% c(-1, .5))
-#' tf_where(lin, value %inr% c(-1, .5), "range")
+#' tf_where(lin, value %inr% c(-1, 0.5))
+#' tf_where(lin, value %inr% c(-1, 0.5), "range")
 #' a <- 1
 #' tf_where(lin, value > a, "first")
 #' tf_where(lin, value < a, "last")
@@ -41,7 +41,7 @@
 #' tf_anywhere(lin, value > 2)
 #'
 #' set.seed(4353)
-#' f <- tf_rgp(5, 11L)
+#' f <- tf_rgp(5, 11)
 #' plot(f, pch = as.character(1:5), points = TRUE)
 #' tf_where(f, value == max(value))
 #' # where is the function increasing/decreasing?
@@ -54,7 +54,7 @@
 #'     sign(c(diff(value), tail(diff(value), 1)))
 #' )
 #' # where in its second half is the function positive?
-#' tf_where(f, arg > .5 & value > 0)
+#' tf_where(f, arg > 0.5 & value > 0)
 #' # does the function ever exceed?
 #' tf_anywhere(f, value > 1)
 #' @importFrom stats setNames

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -14,12 +14,12 @@
 #' @family tidyfun utility functions
 #' @export
 #' @examples
-#' (x <- tf_rgp(10))
+#' x <- tf_rgp(10)
 #' plot(x)
-#' tf_zoom(x, .5, .9)
-#' tf_zoom(x, .5, .9) |> lines(col = "red")
-#' tf_zoom(x, seq(0, .5, length.out = 10),
-#'   seq(.5, 1, length.out = 10)) |> lines(col = "blue", lty = 3)
+#' tf_zoom(x, 0.5, 0.9)
+#' tf_zoom(x, 0.5, 0.9) |> lines(col = "red")
+#' tf_zoom(x, seq(0, 0.5, length.out = 10), seq(0.5, 1, length.out = 10)) |>
+#'   lines(col = "blue", lty = 3)
 tf_zoom <- function(f, begin, end, ...) {
   UseMethod("tf_zoom")
 }

--- a/inst/testdata/make-test-data.R
+++ b/inst/testdata/make-test-data.R
@@ -1,7 +1,7 @@
 set.seed(17711L)
 
 smoo <- tf_rgp(10, nugget = 0)
-rough <- tf_rgp(10, arg = 121L, nugget = .2, scale = .005)
+rough <- tf_rgp(10, arg = 121L, nugget = 0.2, scale = 0.005)
 narrow <- tf_jiggle(tf_rgp(10, arg = 11L, nugget = 0))
 irr <- tf_sparsify(tf_jiggle(smoo))
 sparse <- tf_sparsify(smoo)
@@ -12,6 +12,5 @@ smoo_df <- as.data.frame(smoo, unnest = TRUE)
 
 irr_list <- tf_evaluations(irr)
 irr_matrix <- suppressWarnings(as.matrix(irr))
-irr_df <-  as.data.frame(irr, unnest = TRUE)
-narrow_df <-  as.data.frame(narrow, unnest = TRUE) 
-
+irr_df <- as.data.frame(irr, unnest = TRUE)
+narrow_df <- as.data.frame(narrow, unnest = TRUE)

--- a/man/tf_evaluate.Rd
+++ b/man/tf_evaluate.Rd
@@ -38,9 +38,9 @@ evaluate \code{object}, see examples.
 \examples{
 f <- tf_rgp(3, arg = seq(0, 1, length.out = 11))
 tf_evaluate(f) |> str()
-tf_evaluate(f, arg = .5) |> str()
+tf_evaluate(f, arg = 0.5) |> str()
 # equivalent, as matrix:
-f[, .5]
+f[, 0.5]
 new_grid <- seq(0, 1, length.out = 6)
 tf_evaluate(f, arg = new_grid) |> str()
 # equivalent, as matrix:

--- a/man/tf_interpolate.Rd
+++ b/man/tf_interpolate.Rd
@@ -47,14 +47,16 @@ less_dense <- tf_interpolate(dense, arg = seq(0, 1, length.out = 101))
 # filling out sparse data (use a suitable evaluator -function!)
 sparse <- tf_rgp(10, arg = seq(0, 5, length.out = 21))
 plot(sparse)
-tfd(sparse, evaluator= tf_approx_spline) |>   #change eval. for better interpolation
+# change evaluator for better interpolation
+tfd(sparse, evaluator = tf_approx_spline) |>
   tf_interpolate(arg = seq(0, 5, length.out = 201)) |>
   lines(col = 2)
 
 set.seed(1860)
-(sparse_irregular <- tf_rgp(5) |>  tf_sparsify(.5) |> tf_jiggle())
+sparse_irregular <- tf_rgp(5) |>
+  tf_sparsify(0.5) |>
+  tf_jiggle()
 tf_interpolate(sparse_irregular, arg = seq(0, 1, length.out = 51))
-
 }
 \seealso{
 Other tidyfun inter/extrapolation functions: 

--- a/man/tf_smooth.Rd
+++ b/man/tf_smooth.Rd
@@ -33,7 +33,7 @@ which should be smoothed by using a smaller basis / stronger penalty.
 \code{tf_smooth.tfd} overrides/automatically sets some defaults of the
 used methods:
 \itemize{
-\item \strong{\code{lowess}} uses a span parameter of \code{f} = .15 (instead of .75)
+\item \strong{\code{lowess}} uses a span parameter of \code{f} = 0.15 (instead of 0.75)
 by default.
 \item \strong{\code{rollmean}/\code{median}} use a window size of \code{k} = $<$number of
 grid points$>$/20 (i.e., the nearest odd integer to that) and sets \code{fill=   "extend"} (i.e., constant extrapolation to replace missing values at the
@@ -46,7 +46,7 @@ grid points$>$/10 (i.e., the nearest odd integer to that).
 \examples{
 library(zoo)
 library(pracma)
-f <- tf_sparsify(tf_jiggle(tf_rgp(4, 201L, nugget = .05)))
+f <- tf_sparsify(tf_jiggle(tf_rgp(4, 201, nugget = 0.05)))
 f_lowess <- tf_smooth(f, "lowess")
 # these methods ignore the distances between arg-values:
 f_mean <- tf_smooth(f, "rollmean")
@@ -54,10 +54,14 @@ f_median <- tf_smooth(f, "rollmean", k = 31)
 f_sg <- tf_smooth(f, "savgol", fl = 31)
 layout(t(1:4))
 plot(f, points = FALSE, main = "original")
-plot(f_lowess, points = FALSE, col = "blue", main = "lowess (default,\n span .9 in red)")
-lines(tf_smooth(f, "lowess", f = .9), col = "red", alpha = .2)
-plot(f_mean, points = FALSE, col = "blue", main = "rolling means &\n medians (red)")
-lines(f_median, col = "red", alpha = .2) # note constant extrapolation at both ends!
+plot(f_lowess,
+  points = FALSE, col = "blue", main = "lowess (default,\n span 0.9 in red)"
+)
+lines(tf_smooth(f, "lowess", f = 0.9), col = "red", alpha = 0.2)
+plot(f_mean,
+  points = FALSE, col = "blue", main = "rolling means &\n medians (red)"
+)
+lines(f_median, col = "red", alpha = 0.2) # note constant extrapolation at both ends!
 plot(f, points = FALSE, main = "orginal and\n savgol (red)")
 lines(f_sg, col = "red")
 }

--- a/man/tf_where.Rd
+++ b/man/tf_where.Rd
@@ -52,8 +52,8 @@ Any \code{cond}ition evaluates to \code{NA} on \code{NA}-entries in \code{f}.
 }
 \examples{
 lin <- 1:4 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11))
-tf_where(lin, value \%inr\% c(-1, .5))
-tf_where(lin, value \%inr\% c(-1, .5), "range")
+tf_where(lin, value \%inr\% c(-1, 0.5))
+tf_where(lin, value \%inr\% c(-1, 0.5), "range")
 a <- 1
 tf_where(lin, value > a, "first")
 tf_where(lin, value < a, "last")
@@ -61,7 +61,7 @@ tf_where(lin, value > 2, "any")
 tf_anywhere(lin, value > 2)
 
 set.seed(4353)
-f <- tf_rgp(5, 11L)
+f <- tf_rgp(5, 11)
 plot(f, pch = as.character(1:5), points = TRUE)
 tf_where(f, value == max(value))
 # where is the function increasing/decreasing?
@@ -74,7 +74,7 @@ tf_where(
     sign(c(diff(value), tail(diff(value), 1)))
 )
 # where in its second half is the function positive?
-tf_where(f, arg > .5 & value > 0)
+tf_where(f, arg > 0.5 & value > 0)
 # does the function ever exceed?
 tf_anywhere(f, value > 1)
 }

--- a/man/tf_zoom.Rd
+++ b/man/tf_zoom.Rd
@@ -35,12 +35,12 @@ be turned into irregular \code{tfd}-objects iff \code{begin} or \code{end} are n
 These are used to redefine or restrict the \code{domain} of \code{tf} objects.
 }
 \examples{
-(x <- tf_rgp(10))
+x <- tf_rgp(10)
 plot(x)
-tf_zoom(x, .5, .9)
-tf_zoom(x, .5, .9) |> lines(col = "red")
-tf_zoom(x, seq(0, .5, length.out = 10),
-  seq(.5, 1, length.out = 10)) |> lines(col = "blue", lty = 3)
+tf_zoom(x, 0.5, 0.9)
+tf_zoom(x, 0.5, 0.9) |> lines(col = "red")
+tf_zoom(x, seq(0, 0.5, length.out = 10), seq(0.5, 1, length.out = 10)) |>
+  lines(col = "blue", lty = 3)
 }
 \seealso{
 Other tidyfun utility functions: 

--- a/man/tfb_fpc.Rd
+++ b/man/tfb_fpc.Rd
@@ -58,7 +58,7 @@ tfb_fpc(data, ...)
 \item{...}{arguments to the \code{method} which computes the
 (regularized/smoothed) FPCA.
 Unless set by the user, uses proportion of variance explained
-\code{pve = .995} to determine the truncation levels.}
+\code{pve = 0.995} to determine the truncation levels.}
 
 \item{id}{The name or number of the column defining which data belong to
 which function.}
@@ -110,16 +110,17 @@ data is NULL
 # Apply FPCA for sparse data using refund::fpca.sc:
 set.seed(99290)
 # create sparse data:
-data <- tf_rgp(15) |> tf_sparsify() |> as.data.frame(unnest = TRUE)
+data <- tf_rgp(15) |>
+  tf_sparsify() |>
+  as.data.frame(unnest = TRUE)
 # wrap refund::fpca_sc for use as FPCA method in tfb_fpc:
-fpca_sc_wrapper <- function(data, arg, pve = .995, ...) {
+fpca_sc_wrapper <- function(data, arg, pve = 0.995, ...) {
   data_mat <- tf:::df_2_mat(data)
-  fpca <- refund::fpca.sc(Y = data_mat,
-                          argvals = attr(data_mat, "arg"),
-                          pve = pve, ...)
+  fpca <- refund::fpca.sc(
+    Y = data_mat, argvals = attr(data_mat, "arg"), pve = pve, ...
+  )
   fpca[c("mu", "efunctions", "scores", "npc")]
 }
-tfb_fpc(data, method = fpca_sc_wrapper)
 }
 \seealso{
 \code{\link[=fpc_wsvd]{fpc_wsvd()}} for FPCA options.

--- a/man/tfbrackets.Rd
+++ b/man/tfbrackets.Rd
@@ -63,7 +63,7 @@ elements in between with \code{NAs}. This package was developed by fickle,
 irridescently rainbow-colored unicorns.
 }
 \examples{
-(x <- 1:3 * tfd(data = 0:10, arg = 0:10))
+x <- 1:3 * tfd(data = 0:10, arg = 0:10)
 plot(x)
 # this operator's 2nd argument is quite overloaded -- you can:
 # 1. simply extract elements from the vector if no second arg is given:
@@ -77,6 +77,6 @@ x[1:2, c(4.5, 9), interpolate = FALSE] # NA for arg-values not in the original d
 x[-3, seq(1, 9, by = 2), matrix = FALSE] # list of data.frames for each function
 # in order to evaluate a set of observed functions on a new grid and
 # save them as a functional data vector again, use `tfd` or `tfb` instead:
-tfd(x, arg = seq(0, 10, by = .01), resolution = 1e-3)
+tfd(x, arg = seq(0, 10, by = 0.01), resolution = 1e-3)
 }
 \concept{tidyfun bracket-operator}

--- a/man/tfd.Rd
+++ b/man/tfd.Rd
@@ -142,7 +142,7 @@ implementations of this.
 \strong{\code{resolution}}: \code{arg}-values that are equivalent up to this difference are
 treated as identical. E.g., if an evaluation of \eqn{f(t)} is available at
 \eqn{t=1} and a function value is requested at \eqn{t = 1.01}, \eqn{f(1)}
-will be returned if \code{resolution} < .01. By default, resolution will be set to
+will be returned if \code{resolution} < 0.01. By default, resolution will be set to
 an integer-valued power of 10 one smaller than the smallest difference
 between adjacent \code{arg}-values rounded down to an integer-valued power of 10:
 e.g., if the smallest difference between consecutive \code{arg}-values is between
@@ -151,15 +151,14 @@ e.g., if the smallest difference between consecutive \code{arg}-values is betwee
 \examples{
 # turn irregular to regular tfd by evaluating on a common grid:
 
-(f <- c(
+f <- c(
   tf_rgp(1, arg = seq(0, 1, length.out = 11)),
   tf_rgp(1, arg = seq(0, 1, length.out = 21))
-  ))
+)
 tfd(f, arg = seq(0, 1, length.out = 21))
 
 set.seed(1213)
-(f <- tf_rgp(3, arg = seq(0, 1, length.out = 51)) |>
-  tf_sparsify(.9))
+f <- tf_rgp(3, arg = seq(0, 1, length.out = 51)) |> tf_sparsify(0.9)
 # does not yield regular data because linear extrapolation yields NAs
 #   outside observed range:
 tfd(f, arg = seq(0, 1, length.out = 101))
@@ -167,7 +166,8 @@ tfd(f, arg = seq(0, 1, length.out = 101))
 #   e.g. constant extrapolation:
 tfd(f, evaluator = tf_approx_fill_extend, arg = seq(0, 1, length.out = 101))
 plot(f, col = 2)
-tfd(f, arg = seq(0, 1, length.out = 151),
-    evaluator = tf_approx_fill_extend) |>  lines()
+tfd(f,
+  arg = seq(0, 1, length.out = 151), evaluator = tf_approx_fill_extend
+) |> lines()
 }
 \concept{tfd-class}

--- a/tests/testthat/test-calculus.R
+++ b/tests/testthat/test-calculus.R
@@ -23,35 +23,46 @@ square_b <- tfb(square, k = 45, bs = "tp", verbose = FALSE)
 test_that("basic derivatives work", {
   dgrid <- seq(from + 0.5, to - 0.5, length.out = 50)
 
-  expect_equal(tf_derive(cubic)[, dgrid], square[, dgrid], tolerance = .1)
-  expect_equal(tf_derive(cubic_irreg)[, dgrid], square[, dgrid], tolerance = .1)
-  expect_equal(tf_derive(cubic_b)[, dgrid], square[, dgrid], tolerance = .1,
-               ignore_attr = TRUE)
-  expect_equal(tf_derive(cubic, order = 2)[, dgrid], lin[, dgrid], tolerance = .1)
-  expect_equal(tf_derive(cubic_irreg, order = 2)[, dgrid], lin[, dgrid], tolerance = .1)
-  expect_equal(tf_derive(cubic_b, order = 2)[, dgrid], lin[, dgrid], tolerance = .1,
-               ignore_attr = TRUE)
+  expect_equal(tf_derive(cubic)[, dgrid], square[, dgrid], tolerance = 0.1)
+  expect_equal(tf_derive(cubic_irreg)[, dgrid], square[, dgrid],
+    tolerance = 0.1
+  )
+  expect_equal(tf_derive(cubic_b)[, dgrid], square[, dgrid],
+    tolerance = 0.1, ignore_attr = TRUE
+  )
+  expect_equal(tf_derive(cubic, order = 2)[, dgrid], lin[, dgrid],
+    tolerance = 0.1
+  )
+  expect_equal(tf_derive(cubic_irreg, order = 2)[, dgrid], lin[, dgrid],
+    tolerance = 0.1
+  )
+  expect_equal(tf_derive(cubic_b, order = 2)[, dgrid], lin[, dgrid],
+    tolerance = 0.1,
+    ignore_attr = TRUE
+  )
 })
 
 test_that("basic definite integration works", {
-  expect_equal(tf_integrate(square), to^3 - from^3, tolerance = .1)
-  expect_equal(tf_integrate(square_irreg), to^3 - from^3, tolerance = .1)
-  expect_equal(tf_integrate(square_b), to^3 - from^3, tolerance = .1,
-               ignore_attr = TRUE)
+  expect_equal(tf_integrate(square), to^3 - from^3, tolerance = 0.1)
+  expect_equal(tf_integrate(square_irreg), to^3 - from^3, tolerance = 0.1)
+  expect_equal(tf_integrate(square_b), to^3 - from^3,
+    tolerance = 0.1,
+    ignore_attr = TRUE
+  )
 })
 
 test_that("basic antiderivatives work", {
   expect_equal(tf_integrate(square, definite = FALSE)[, dgrid],
     cubic[, dgrid] - from^3,
-    tolerance = .1
+    tolerance = 0.1
   )
   expect_equal(tf_integrate(square_irreg, definite = FALSE)[, dgrid],
     cubic[, dgrid] - from^3,
-    tolerance = .1
+    tolerance = 0.1
   )
   expect_equal(tf_integrate(square_b, definite = FALSE)[, dgrid],
     cubic[, dgrid] - from^3,
-    tolerance = .1, ignore_attr = TRUE
+    tolerance = 0.1, ignore_attr = TRUE
   )
 })
 
@@ -61,20 +72,21 @@ test_that("deriv & tf_integrate are reversible (approximately)", {
   f <- f - f[, grid[1]] # start at  0
   f2 <- tf_integrate(tf_derive(f), definite = FALSE)
   f3 <- tf_derive(tf_integrate(f, definite = FALSE))
-  expect_equal(f[, dgrid], f2[, dgrid], tolerance = .1)
-  expect_equal(f[, dgrid], f3[, dgrid], tolerance = .1)
+  expect_equal(f[, dgrid], f2[, dgrid], tolerance = 0.1)
+  expect_equal(f[, dgrid], f3[, dgrid], tolerance = 0.1)
 
   expect_error(
     tf_integrate(tf_derive(tfb(f, verbose = FALSE)), definite = FALSE),
     "previously"
   )
 
-  f_pc <- tfb_fpc(f[1:3, seq(tf_domain(f)[1], tf_domain(f)[2], length.out = 101)],
+  f_pc <- tfb_fpc(
+    f[1:3, seq(tf_domain(f)[1], tf_domain(f)[2], length.out = 101)],
     smooth = FALSE, verbose = FALSE
   )
   f_pc2 <- tf_integrate(tf_derive(f_pc), definite = FALSE)
   f_pc3 <- tf_derive(tf_integrate(f_pc, definite = FALSE))
-  expect_equal(f_pc[, dgrid], f_pc2[, dgrid], tolerance = .1)
-  expect_equal(f_pc[, dgrid], f_pc3[, dgrid], tolerance = .1)
-  expect_equal(tf_integrate(f_pc), tf_integrate(f[1:3]), tolerance = .01)
+  expect_equal(f_pc[, dgrid], f_pc2[, dgrid], tolerance = 0.1)
+  expect_equal(f_pc[, dgrid], f_pc3[, dgrid], tolerance = 0.1)
+  expect_equal(tf_integrate(f_pc), tf_integrate(f[1:3]), tolerance = 0.01)
 })

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -27,8 +27,8 @@ test_that("MBD works", {
   expect_equal(rank(tf_depth(lin_b, depth = "MBD")), ranks)
   # weighting by interval length:
   # increases importance of last point -> lower tf_depth
-  expect_true(
-    tail(tf_depth(spike_regular), 1) > tail(tf_depth(spike_irregular), 1)
+  expect_gt(
+    tail(tf_depth(spike_regular), 1), tail(tf_depth(spike_irregular), 1)
   )
 })
 

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -1,5 +1,5 @@
 grid <- round(seq(0, 10, length.out = 11), 3)
-lin <- -3:3 * tfd(.1 * grid, grid)
+lin <- -3:3 * tfd(0.1 * grid, grid)
 parallel <- -3:3 + tfd(0 * grid, grid)
 names(lin) <- names(parallel) <- 1:7
 

--- a/tests/testthat/test-evaluator.R
+++ b/tests/testthat/test-evaluator.R
@@ -64,7 +64,7 @@ test_that("evaluator tf_approx_spline works", {
 test_that("multiple arg-vectors work for tfb", {
   fb <- tfb(tf_rgp(3), verbose = FALSE)
   expect_equal(
-    unlist(tf_evaluate(fb, as.list(c(0, .5, 1)))),
+    unlist(tf_evaluate(fb, as.list(c(0, 0.5, 1)))),
     unlist(c(
       tf_evaluate(fb[1], 0), tf_evaluate(fb[2], 0.5), tf_evaluate(fb[3], 1)
     ))
@@ -72,7 +72,7 @@ test_that("multiple arg-vectors work for tfb", {
 })
 
 test_that("resolution finding works", {
-  fi <- tfd(list(c(1, 2), c(1, 2)), arg = list(c(0, .1), c(1, 2)))
+  fi <- tfd(list(c(1, 2), c(1, 2)), arg = list(c(0, 0.1), c(1, 2)))
   expect_equal(attr(fi, "resolution"), 0.01)
   f <- tf_rgp(3, 101L)
   expect_equal(attr(f, "resolution"), 1e-4)
@@ -82,11 +82,11 @@ test_that("resolution finding works", {
 
 test_that("resolution warnings work", {
   expect_error(
-    tfd(list(c(1, 2), c(1, 2)), arg = list(c(0, .1), c(1, 2)), resolution = 1),
+    tfd(list(c(1, 2), c(1, 2)), arg = list(c(0, 0.1), c(1, 2)), resolution = 1),
     "Non-unique arg-values"
   )
   expect_error(
-    tfd(c(0, 1), arg = c(0, .1), resolution = .5),
+    tfd(c(0, 1), arg = c(0, 0.1), resolution = 0.5),
     "Non-unique arg-values"
   )
   expect_error(
@@ -96,21 +96,21 @@ test_that("resolution warnings work", {
 })
 
 test_that("resolution works as expected", {
-  f <- tfd(1:10, 1:10, resolution = .05, evaluator = tf_approx_none)
+  f <- tfd(1:10, 1:10, resolution = 0.05, evaluator = tf_approx_none)
   set.seed(122)
   fi <- tf_sparsify(f)
   tf_evaluator(fi) <- tf_approx_none
   fb <- tfb(f, verbose = FALSE)
 
   # argvals +/- resolution/2 are not distinguished:
-  expect_equal(f[, 1:9 + .01], f[, 1:9], ignore_attr = TRUE)
-  expect_equal(f[, 1:9 + .0249], f[, 1:9], ignore_attr = TRUE)
-  expect_true(all(is.na(f[, 1:9 + .0251])))
+  expect_equal(f[, 1:9 + 0.01], f[, 1:9], ignore_attr = TRUE)
+  expect_equal(f[, 1:9 + 0.0249], f[, 1:9], ignore_attr = TRUE)
+  expect_true(all(is.na(f[, 1:9 + 0.0251])))
 
-  expect_equal(fi[, 1:9 + .01], fi[, 1:9], ignore_attr = TRUE)
-  expect_equal(fi[, 1:9 + .0249], fi[, 1:9], ignore_attr = TRUE)
-  expect_true(all(is.na(fi[, 1:9 + .0251])))
+  expect_equal(fi[, 1:9 + 0.01], fi[, 1:9], ignore_attr = TRUE)
+  expect_equal(fi[, 1:9 + 0.0249], fi[, 1:9], ignore_attr = TRUE)
+  expect_true(all(is.na(fi[, 1:9 + 0.0251])))
 
-  expect_equal(fb[, 1:9 + .01], fb[, 1:9], ignore_attr = TRUE)
-  expect_equal(fb[, 1:9 + .0249], fb[, 1:9], ignore_attr = TRUE)
+  expect_equal(fb[, 1:9 + 0.01], fb[, 1:9], ignore_attr = TRUE)
+  expect_equal(fb[, 1:9 + 0.0249], fb[, 1:9], ignore_attr = TRUE)
 })

--- a/tests/testthat/test-tfb-fpc.R
+++ b/tests/testthat/test-tfb-fpc.R
@@ -43,14 +43,14 @@ test_that("fpc_wsvd works for smooth non-equidistant data", {
 
 test_that("tfb_fpc defaults work for all kinds of regular input", {
   expect_s3_class(tfb_fpc(smoo), "tfb_fpc")
-  expect_equal(length(tfb_fpc(smoo)), length(smoo))
+  expect_length(tfb_fpc(smoo), length(smoo))
   expect_equal(
     tf_evaluations(tfb_fpc(smoo, pve = 0.9999)), tf_evaluations(smoo),
     tolerance = 1e-1, ignore_attr = TRUE
   )
   for (smoo_ in list(tfb_fpc(smoo_matrix, pve = 0.9999), tfb_fpc(smoo_df))) {
     expect_s3_class(smoo_, "tfb_fpc")
-    expect_equal(length(smoo_), length(smoo))
+    expect_length(smoo_, length(smoo))
     expect_equal(tf_evaluations(smoo_), tf_evaluations(smoo),
       tolerance = 1e-1, ignore_attr = TRUE
     )

--- a/tests/testthat/test-tfb-fpc.R
+++ b/tests/testthat/test-tfb-fpc.R
@@ -25,7 +25,7 @@ test_that("fpc_wsvd works for smooth equidistant data", {
 })
 
 test_that("fpc_wsvd works for smooth non-equidistant data", {
-  smoo_arg <- (2 * qbeta(attr(smoo_matrix, "arg"), .5, .8) + 1)^3
+  smoo_arg <- (2 * qbeta(attr(smoo_matrix, "arg"), 0.5, 0.8) + 1)^3
   fpc_smoo <- fpc_wsvd(smoo_matrix, smoo_arg, pve = 1.0)
   expect_equal(fpc_smoo$npc, length(smoo) - 1)
   expect_equal(fpc_smoo$mu, tf_evaluations(mean(smoo))[[1]], ignore_attr = TRUE)
@@ -45,10 +45,10 @@ test_that("tfb_fpc defaults work for all kinds of regular input", {
   expect_s3_class(tfb_fpc(smoo), "tfb_fpc")
   expect_equal(length(tfb_fpc(smoo)), length(smoo))
   expect_equal(
-    tf_evaluations(tfb_fpc(smoo, pve = .9999)), tf_evaluations(smoo),
+    tf_evaluations(tfb_fpc(smoo, pve = 0.9999)), tf_evaluations(smoo),
     tolerance = 1e-1, ignore_attr = TRUE
   )
-  for (smoo_ in list(tfb_fpc(smoo_matrix, pve = .9999), tfb_fpc(smoo_df))) {
+  for (smoo_ in list(tfb_fpc(smoo_matrix, pve = 0.9999), tfb_fpc(smoo_df))) {
     expect_s3_class(smoo_, "tfb_fpc")
     expect_equal(length(smoo_), length(smoo))
     expect_equal(tf_evaluations(smoo_), tf_evaluations(smoo),

--- a/tests/testthat/test-tfb-fpc.R
+++ b/tests/testthat/test-tfb-fpc.R
@@ -5,9 +5,9 @@ test_that("fpc_wsvd works for smooth equidistant data", {
   expect_type(
     fpc_wsvd(smoo_matrix, attr(smoo_matrix, "arg"), pve = 1.0), "list"
   )
-  expect_true(
-    fpc_wsvd(smoo_matrix, attr(smoo_matrix, "arg"), pve = 0.5)$npc <
-      fpc_wsvd(smoo_matrix, attr(smoo_matrix, "arg"), pve = 0.9)$npc
+  expect_lt(
+    fpc_wsvd(smoo_matrix, attr(smoo_matrix, "arg"), pve = 0.5)$npc,
+    fpc_wsvd(smoo_matrix, attr(smoo_matrix, "arg"), pve = 0.9)$npc
   )
   fpc_smoo <- fpc_wsvd(smoo_matrix, attr(smoo_matrix, "arg"), pve = 1.0)
   expect_equal(fpc_smoo$npc, length(smoo) - 1)

--- a/tests/testthat/test-tfb-spline.R
+++ b/tests/testthat/test-tfb-spline.R
@@ -4,7 +4,7 @@ source(system.file("testdata", "make-test-data.R", package = "tf"))
 test_that("tfb_spline defaults work for all kinds of regular input", {
   expect_s3_class(tfb_spline(smoo, verbose = FALSE), "tfb_spline")
   expect_message(tfb_spline(smoo), "100")
-  expect_equal(length(tfb_spline(smoo, verbose = FALSE)), length(smoo))
+  expect_length(tfb_spline(smoo, verbose = FALSE), length(smoo))
   expect_equal(
     tf_evaluations(tfb_spline(smoo, verbose = FALSE)), tf_evaluations(smoo),
     tolerance = 1e-3
@@ -12,7 +12,7 @@ test_that("tfb_spline defaults work for all kinds of regular input", {
   for (dat in list(smoo_list, smoo_matrix, smoo_df)) {
     smoo_ <- try(tfb_spline(dat, verbose = FALSE))
     expect_s3_class(smoo_, "tfb_spline")
-    expect_equal(length(smoo_), length(smoo))
+    expect_length(smoo_, length(smoo))
     expect_equal(
       tf_evaluations(smoo_), tf_evaluations(smoo),
       tolerance = 1e-3, ignore_attr = TRUE
@@ -23,12 +23,12 @@ test_that("tfb_spline defaults work for all kinds of regular input", {
 test_that("tfb_spline defaults work for all kinds of irregular input", {
   expect_s3_class(tfb_spline(irr, verbose = FALSE), "tfb_spline")
   expect_message(tfb_spline(irr), "100")
-  expect_equal(length(tfb_spline(irr, verbose = FALSE)), length(irr))
+  expect_length(tfb_spline(irr, verbose = FALSE), length(irr))
   expect_message(tfb_spline(irr_df), "100")
 
   irr_tfb_ <- tfb_spline(irr_list, arg = tf_arg(irr), verbose = FALSE)
   expect_s3_class(irr_tfb_, "tfb_spline")
-  expect_equal(length(irr_tfb_), length(irr))
+  expect_length(irr_tfb_, length(irr))
   expect_equal(
     tf_evaluate(irr_tfb_, tf_arg(irr)), tf_evaluations(irr),
     tolerance = 1e-1
@@ -37,7 +37,7 @@ test_that("tfb_spline defaults work for all kinds of irregular input", {
   for (dat in list(irr_matrix, irr_df)) {
     irr_tfb_ <- tfb_spline(dat, verbose = FALSE)
     expect_s3_class(irr_tfb_, "tfb_spline")
-    expect_equal(length(irr_tfb_), length(irr))
+    expect_length(irr_tfb_, length(irr))
     expect_equal(
       tf_evaluate(irr_tfb_, tf_arg(irr)), tf_evaluations(irr),
       tolerance = 1e-1, ignore_attr = TRUE
@@ -108,7 +108,7 @@ test_that("unpenalized tfb_spline works", {
   ) |>
     as.matrix() |>
     sum()
-  expect_true(approx_penalized > approx_unpenalized)
+  expect_gt(approx_penalized, approx_unpenalized)
 })
 
 test_that("mgcv spline basis options work", {

--- a/tests/testthat/test-tfb-spline.R
+++ b/tests/testthat/test-tfb-spline.R
@@ -120,8 +120,8 @@ test_that("mgcv spline basis options work", {
     )
     smoo_spec <- environment(attr(smoo_, "basis"))$spec
     expect_equal(smoo_spec$bs.dim, 21)
-    expect_equal(
-      class(smoo_spec),
+    expect_s3_class(
+      smoo_spec,
       class(smooth.construct(
         s(x, bs = bs),
         data = list(x = 1:40), knots = NULL

--- a/tests/testthat/test-tfb-spline.R
+++ b/tests/testthat/test-tfb-spline.R
@@ -134,10 +134,10 @@ test_that("mgcv spline basis options work", {
 test_that("global and pre-specified smoothing options work", {
   rough_global <- try(tfb(rough, global = TRUE, k = 51, verbose = FALSE))
   expect_s3_class(rough_global, "tfb")
-  expect_true(
+  expect_gt(
     system.time(
       tfb(c(rough, rough, rough), k = 51, verbose = FALSE)
-    )["elapsed"] >
+    )["elapsed"],
       system.time(
         tfb(c(rough, rough, rough), k = 51, global = TRUE, verbose = FALSE)
       )["elapsed"]

--- a/tests/testthat/test-tfb-spline.R
+++ b/tests/testthat/test-tfb-spline.R
@@ -83,7 +83,7 @@ test_that("unpenalized tfb_spline works", {
       log() |>
       as.matrix(),
     as.matrix(smoo),
-    tolerance = .001
+    tolerance = 0.001
   )
 
   expect_message(
@@ -148,8 +148,8 @@ test_that("global and pre-specified smoothing options work", {
     tfb(rough, penalized = FALSE, k = 51, verbose = FALSE) |> tf_evaluations()
   )
   expect_equal(
-    tfb(rough, sp = .2, k = 75, verbose = FALSE) |> tf_evaluations(),
-    tfb(rough, sp = .2, k = 10, verbose = FALSE) |> tf_evaluations(),
+    tfb(rough, sp = 0.2, k = 75, verbose = FALSE) |> tf_evaluations(),
+    tfb(rough, sp = 0.2, k = 10, verbose = FALSE) |> tf_evaluations(),
     tolerance = 1e-2
   )
 
@@ -168,10 +168,10 @@ test_that("global and pre-specified smoothing options work", {
   )
   expect_equal(
     tfb(exp(rough),
-      sp = .2, k = 75, family = gaussian(link = "log"), verbose = FALSE
+      sp = 0.2, k = 75, family = gaussian(link = "log"), verbose = FALSE
     ) |> tf_evaluations(),
     tfb(exp(rough),
-      sp = .2, k = 10, family = gaussian(link = "log"), verbose = FALSE
+      sp = 0.2, k = 10, family = gaussian(link = "log"), verbose = FALSE
     ) |> tf_evaluations(),
     tolerance = 1e-2
   )

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,19 @@
+test_that("round_resolution works", {
+  # works with default and updown = 0
+  expect_equal(round_resolution(1.5, 1), 2)
+  expect_equal(round_resolution(2.5, 1), 2)
+  expect_equal(round_resolution(2.49, 1, updown = 0), 2)
+  # works with updown > 0
+  expect_equal(round_resolution(1.1, 1, 1), 2)
+  expect_equal(round_resolution(2.9, 1, 1), 3)
+  # works with updown < 0
+  expect_equal(round_resolution(1.9, 1, -1), 1)
+  expect_equal(round_resolution(2.1, 1, -1), 2)
+  # negative numbers
+  expect_equal(round_resolution(-1.5, 1), -2)
+  expect_equal(round_resolution(-2.5, 1, 1), -2)
+  expect_equal(round_resolution(-2.5, 1, -1), -3)
+  # handle NA
+  expect_true(is.na(round_resolution(NA, 1)))
+  expect_true(is.na(round_resolution(1.5, NA)))
+})

--- a/tests/testthat/test-where.R
+++ b/tests/testthat/test-where.R
@@ -2,7 +2,7 @@ test_that("tf_where basics work", {
   lin <- 1:2 * tfd(seq(-1, 1, length.out = 11), seq(-1, 1, length.out = 11)) +
     c(0, 0.1)
   expect_equal(
-    tf_where(lin, value %inr% c(-1, -.5)),
+    tf_where(lin, value %inr% c(-1, -0.5)),
     list(c(-1.0, -0.8, -0.6), c(-0.4))
   )
   expect_equal(

--- a/tests/testthat/test-zoom.R
+++ b/tests/testthat/test-zoom.R
@@ -1,6 +1,6 @@
 set.seed(123)
-x <- tf_rgp(4, arg = seq(0, 1, length.out = 51), nugget = .1)
-xi <- tf_sparsify(tf_jiggle(x), .2)
+x <- tf_rgp(4, arg = seq(0, 1, length.out = 51), nugget = 0.1)
+xi <- tf_sparsify(tf_jiggle(x), 0.2)
 xb <- tfb(x, verbose = FALSE)
 xbi <- tfb(xi, verbose = FALSE)
 
@@ -8,43 +8,43 @@ xfpc <- tfb_fpc(x, verbose = FALSE)
 
 
 test_that("tf_zoom for tfd works", {
-  expect_equal(tf_domain(tf_zoom(x, .2, .8)), c(.2, .8))
-  expect_equal(tf_domain(tf_zoom(xi, .2, .8)), c(.2, .8))
+  expect_equal(tf_domain(tf_zoom(x, 0.2, 0.8)), c(0.2, 0.8))
+  expect_equal(tf_domain(tf_zoom(xi, 0.2, 0.8)), c(0.2, 0.8))
   expect_equal(
-    as.matrix(tf_zoom(x, 0, .5)), as.matrix(x)[, 1:26],
+    as.matrix(tf_zoom(x, 0, 0.5)), as.matrix(x)[, 1:26],
     ignore_attr = TRUE
   )
   expect_equal(
-    as.data.frame(tf_zoom(xi, 0, .5), unnest = TRUE),
-    as.data.frame(xi, unnest = TRUE) |> subset(arg <= .5),
+    as.data.frame(tf_zoom(xi, 0, 0.5), unnest = TRUE),
+    as.data.frame(xi, unnest = TRUE) |> subset(arg <= 0.5),
     ignore_attr = TRUE
   )
 
-  expect_error(tf_zoom(x, c(.8, .1)))
-  expect_error(tf_zoom(x, .11, .111), "no data")
+  expect_error(tf_zoom(x, c(0.8, 0.1)))
+  expect_error(tf_zoom(x, 0.11, 0.111), "no data")
   expect_error(tf_zoom(xi, 0.051, 0.0511), "no data")
 
-  expect_true(is_irreg(tf_zoom(x, .2, seq(.3, 1, length.out = length(x)))))
+  expect_true(is_irreg(tf_zoom(x, 0.2, seq(0.3, 1, length.out = length(x)))))
 })
 
 test_that("tf_zoom for tfb_spline works", {
-  expect_equal(tf_domain(tf_zoom(xb, .2, .8)), c(.2, .8))
-  expect_equal(tf_domain(tf_zoom(xbi, .2, .8)), c(.2, .8))
+  expect_equal(tf_domain(tf_zoom(xb, 0.2, 0.8)), c(0.2, 0.8))
+  expect_equal(tf_domain(tf_zoom(xbi, 0.2, 0.8)), c(0.2, 0.8))
   expect_equal(
-    as.matrix(tf_zoom(xb, 0, .5)), as.matrix(xb)[, 1:26],
+    as.matrix(tf_zoom(xb, 0, 0.5)), as.matrix(xb)[, 1:26],
     ignore_attr = TRUE
   )
   expect_equal(
-    as.data.frame(tf_zoom(xbi, 0, .5), unnest = TRUE),
-    as.data.frame(xbi, unnest = TRUE) |> subset(arg <= .5),
+    as.data.frame(tf_zoom(xbi, 0, 0.5), unnest = TRUE),
+    as.data.frame(xbi, unnest = TRUE) |> subset(arg <= 0.5),
     ignore_attr = TRUE
   )
 
-  expect_error(tf_zoom(xb, c(.8, .1)))
-  expect_error(tf_zoom(xb, .11, .111), "no data")
+  expect_error(tf_zoom(xb, c(0.8, 0.1)))
+  expect_error(tf_zoom(xb, 0.11, 0.111), "no data")
 
   expect_message(
-    out <- tf_zoom(xb, .2, seq(.3, 1, length.out = length(x))),
+    out <- tf_zoom(xb, 0.2, seq(0.3, 1, length.out = length(x))),
     "converting to tfd"
   )
   expect_true(is_irreg(out))
@@ -52,25 +52,25 @@ test_that("tf_zoom for tfb_spline works", {
 
 test_that("tf_zoom for tfb_fpc works", {
   expect_warning(
-    tf_zoom(xfpc, .2, .8), "orthogonality of FPC basis"
+    tf_zoom(xfpc, 0.2, 0.8), "orthogonality of FPC basis"
   )
   expect_equal(
-    tf_domain(suppressWarnings(tf_zoom(xfpc, .2, .8))),
-    c(.2, .8)
+    tf_domain(suppressWarnings(tf_zoom(xfpc, 0.2, 0.8))),
+    c(0.2, 0.8)
   )
   expect_equal(
-    suppressWarnings(as.matrix(tf_zoom(xfpc, 0, .5))), as.matrix(xfpc)[, 1:26],
+    suppressWarnings(as.matrix(tf_zoom(xfpc, 0, 0.5))), as.matrix(xfpc)[, 1:26],
     ignore_attr = TRUE
   )
   expect_equal(
-    suppressWarnings(as.data.frame(tf_zoom(xfpc, 0, .5), unnest = TRUE)),
-    as.data.frame(xfpc, unnest = TRUE) |> subset(arg <= .5),
+    suppressWarnings(as.data.frame(tf_zoom(xfpc, 0, 0.5), unnest = TRUE)),
+    as.data.frame(xfpc, unnest = TRUE) |> subset(arg <= 0.5),
     ignore_attr = TRUE
   )
 
-  expect_error(suppressWarnings(tf_zoom(xfpc, .8, .1)))
-  expect_error(suppressWarnings(tf_zoom(xfpc, .11, .111)), "no data")
+  expect_error(suppressWarnings(tf_zoom(xfpc, 0.8, 0.1)))
+  expect_error(suppressWarnings(tf_zoom(xfpc, 0.11, 0.111)), "no data")
   expect_true(suppressWarnings(
-    is_irreg(tf_zoom(xfpc, .2, seq(.3, 1, length.out = length(x))))
+    is_irreg(tf_zoom(xfpc, 0.2, seq(0.3, 1, length.out = length(x))))
   ))
 })


### PR DESCRIPTION
- Replace `stopifnot(inherits(...))` for `checkmate::assert_class(...)`
- Replace `stopifnot(is.numeric(x))` for `checkmate::assert_numeric(x)`
- Simplify `round_resolution` and add tests for it
- Replace `.5` pattern for `0.5` for consistency
- Format examples
- Make use of `anyNA` (more efficient)
- Make use of `expect_length`, `expect_lt` and `expect_gt`
- Replace `paste(..., collapse = ", ")` with `toString(x)`
- Explicit check for `anyDuplicated(.)` instead of implicit
- Use `fixed = TRUE` with `grep` where relevant (more efficient)
- Use `nzchar` for checking empty strings (more efficient)