### PR TITLE
refactor: use assignment operator, use leading zero, one call to format_bib

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,30 +2,30 @@ Package: tf
 Title: S3 Classes and Methods for Tidy Functional Data
 Version: 0.3.4
 Authors@R: c(
-    person("Fabian", "Scheipl", email = "fabian.scheipl@googlemail.com", role = c("aut", "cre"),
+    person("Fabian", "Scheipl", , "fabian.scheipl@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8172-3603")),
     person("Jeff", "Goldsmith", role = "aut"),
-    person("Julia", "Wrobel", role = "ctb", 
+    person("Julia", "Wrobel", role = "ctb",
            comment = c(ORCID = "0000-0001-6783-1421")),
     person("Maximilian", "Muecke", role = "ctb",
            comment = c(ORCID = "0009-0000-9432-9795")),
     person("Sebastian", "Fischer", role = "ctb",
            comment = c(ORCID = "0000-0002-9609-3197")),
-    person("Trevor", "Hastie", role = "ctb", 
-           comment = "softImpute author"),       
-    person("Rahul", "Mazumder", role = "ctb", 
+    person("Trevor", "Hastie", role = "ctb",
            comment = "softImpute author"),
-    person("Chen", "Meng", role = "ctb", 
+    person("Rahul", "Mazumder", role = "ctb",
+           comment = "softImpute author"),
+    person("Chen", "Meng", role = "ctb",
            comment = "mogsa author")
   )
-Description: Defines S3 vector data types for vectors of functional data 
-   (grid-based, spline-based or functional principal components-based) with all 
-   arithmetic and summary methods, derivation, integration and smoothing, 
-   plotting, data import and export, and data wrangling, such as re-evaluating, 
-   subsetting, sub-assigning, zooming into sub-domains, or extracting functional 
-   features like minima/maxima and their locations. 
-   The implementation allows including such vectors in data frames for joint 
-   analysis of functional and scalar variables.
+Description: Defines S3 vector data types for vectors of functional data
+    (grid-based, spline-based or functional principal components-based)
+    with all arithmetic and summary methods, derivation, integration and
+    smoothing, plotting, data import and export, and data wrangling, such
+    as re-evaluating, subsetting, sub-assigning, zooming into sub-domains,
+    or extracting functional features like minima/maxima and their
+    locations.  The implementation allows including such vectors in data
+    frames for joint analysis of functional and scalar variables.
 License: AGPL (>= 3)
 URL: https://tidyfun.github.io/tf/, https://github.com/tidyfun/tf/
 BugReports: https://github.com/tidyfun/tf/issues
@@ -48,6 +48,7 @@ Suggests:
     knitr,
     refund,
     testthat (>= 3.0.0)
+Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
@@ -87,4 +88,3 @@ Collate:
     'vctrs-ptype2.R'
     'where.R'
     'zoom.R'
-Config/testthat/edition: 3

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -20,7 +20,7 @@ bibentries <- c(
     publisher = "Taylor & Francis"
   ),
   mazumder2010 = bibentry("article",
-    title= "Spectral regularization algorithms for learning large incomplete matrices",
+    title = "Spectral regularization algorithms for learning large incomplete matrices",
     author = "Mazumder, Rahul and Hastie, Trevor and Tibshirani, Robert",
     journal = "The Journal of Machine Learning Research",
     volume = "11",

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -71,7 +71,7 @@
       assert_subset(i, names(x))
       i <- match(i, names(x))
     }
-    assert_int(i,
+    assert_integerish(i,
       lower = -length(x), upper = length(x),
       any.missing = FALSE
     )

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -71,7 +71,7 @@
       assert_subset(i, names(x))
       i <- match(i, names(x))
     }
-    assert_integerish(i,
+    assert_int(i,
       lower = -length(x), upper = length(x),
       any.missing = FALSE
     )

--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -59,7 +59,7 @@ df_2_mat <- function(data, binning = FALSE, maxbins = 1000) {
   colnames(data_mat) <- binvalues
   attr(data_mat, "arg") <- binvalues
   data_mat[cbind(newid, as.numeric(newindex))] <- data$value
-  return(data_mat)
+  data_mat
 }
 
 #-------------------------------------------------------------------------------

--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -86,8 +86,8 @@ mat_2_df <- function(x, arg) {
   id <- ordered(id, levels = unique(id))
   df_2_df(data.frame(
     # use t(x) here so that order of vector remains unchanged...
-    id = id[col(t(x))], arg = arg[row(t(x))],
-    value = as.vector(t(x)),
-    stringsAsFactors = FALSE
+    id = id[col(t(x))],
+    arg = arg[row(t(x))],
+    value = as.vector(t(x))
   ))
 }

--- a/R/fwise.R
+++ b/R/fwise.R
@@ -52,32 +52,36 @@ tf_fwise <- function(x, .f, arg = tf_arg(x), ...) {
   ret <- map(x_, f_map)
   setNames(ret, names(x))
 }
+
 #' @export
 #' @describeIn functionwise maximal value of each function
 #' @inheritParams base::min
 tf_fmax <- function(x, arg = tf_arg(x), na.rm = FALSE) {
-  ret <- tf_fwise(x, ~ max(.x$value, na.rm = na.rm), arg = arg) |> list_c()
+  ret <- tf_fwise(x, \(.x) max(.x$value, na.rm = na.rm), arg = arg) |> list_c()
   setNames(ret, names(x))
 }
+
 #' @export
 #' @describeIn functionwise minimal value of each function
 #' @inheritParams base::min
 tf_fmin <- function(x, arg = tf_arg(x), na.rm = FALSE) {
-  ret  <- tf_fwise(x, ~ min(.x$value, na.rm = na.rm), arg = arg) |> list_c()
+  ret <- tf_fwise(x, \(.x) min(.x$value, na.rm = na.rm), arg = arg) |> list_c()
   setNames(ret, names(x))
 }
+
 #' @export
 #' @describeIn functionwise median value of each function
 #' @inheritParams base::min
 tf_fmedian <- function(x, arg = tf_arg(x), na.rm = FALSE) {
-  ret  <- tf_fwise(x, ~ median(.x$value, na.rm = na.rm), arg = arg) |> list_c()
+  ret <- tf_fwise(x, \(.x) median(.x$value, na.rm = na.rm), arg = arg) |> list_c()
   setNames(ret, names(x))
 }
+
 #' @export
 #' @describeIn functionwise range of values of each function
 #' @inheritParams base::range
 tf_frange <- function(x, arg = tf_arg(x), na.rm = FALSE, finite = FALSE) {
-  tf_fwise(x, ~ range(.x$value, na.rm = na.rm, finite = finite), arg = arg)
+  tf_fwise(x, \(.x) range(.x$value, na.rm = na.rm, finite = finite), arg = arg)
 }
 
 #' @export
@@ -90,8 +94,9 @@ tf_fmean <- function(x, arg = tf_arg(x)) {
   x_ <- tf_interpolate(x, arg = arg)
   arg <- ensure_list(arg)
   length <- map_dbl(arg, max) - map_dbl(arg, min)
-  tf_integrate(x_)/length
+  tf_integrate(x_) / length
 }
+
 #' @export
 #' @describeIn functionwise variance of each function:
 #'   \eqn{\tfrac{1}{|T|}\int_T (x_i(t) - \bar x(t))^2 dt}
@@ -102,10 +107,11 @@ tf_fvar <- function(x, arg = tf_arg(x)) {
   arg <- ensure_list(arg)
   length <- map_dbl(arg, max) - map_dbl(arg, min)
   x_ <- tf_interpolate(x, arg = arg)
-  x_mean <- tf_integrate(x_)/length
+  x_mean <- tf_integrate(x_) / length
   x_c <- x_ - x_mean
-  tf_integrate(x_c^2)/length
+  tf_integrate(x_c^2) / length
 }
+
 #' @export
 #' @describeIn functionwise standard deviation of each function:
 #'   \eqn{\sqrt{\tfrac{1}{|T|}\int_T (x_i(t) - \bar x(t))^2 dt}}
@@ -120,7 +126,7 @@ tf_crosscov <- function(x, y, arg = tf_arg(x)) {
   # check same domain, arg
   checkmate::assert_class(x, "tf")
   checkmate::assert_class(y, "tf")
-  if (!any(c(length(x) == length(y), length(x) == 1, length(y) == 1))) {
+  if (length(x) != length(y) && length(x) != 1 && length(y) != 1) {
     stop("x or y must have length 1 or the same lengths.", call. = FALSE)
   }
   assert_arg(arg = arg, x = x)
@@ -132,17 +138,16 @@ tf_crosscov <- function(x, y, arg = tf_arg(x)) {
   # set up common args
   x_ <- tf_interpolate(x, arg = arg)
   y_ <- tf_interpolate(y, arg = arg)
-  x_mean <- tf_integrate(x_)/length
-  y_mean <- tf_integrate(y_)/length
+  x_mean <- tf_integrate(x_) / length
+  y_mean <- tf_integrate(y_) / length
   x_c <- x_ - x_mean
   y_c <- y_ - y_mean
   tf_integrate(x_c * y_c) / length
 }
+
 #' @export
 #' @describeIn functionwise cross-correlation between two functional vectors:
 #'   `tf_crosscov(x, y) / (tf_fsd(x) * tf_fsd(y))`
 tf_crosscor <- function(x, y, arg = tf_arg(x)) {
   tf_crosscov(x, y, arg) / sqrt(tf_fvar(x, arg) * tf_fvar(y, arg))
 }
-
-

--- a/R/fwise.R
+++ b/R/fwise.R
@@ -38,9 +38,9 @@ NULL
 #' plot(x_std, col = 1:3)
 #' # Custom functions:
 #' # 80%tiles of each function's values:
-#' tf_fwise(x, ~ quantile(.x$value, .8)) |> unlist()
-#' # minimal value of each function for t >.5
-#' tf_fwise(x, ~ min(.x$value[.x$arg > .5])) |> unlist()
+#' tf_fwise(x, ~ quantile(.x$value, 0.8)) |> unlist()
+#' # minimal value of each function for t > 0.5
+#' tf_fwise(x, ~ min(.x$value[.x$arg > 0.5])) |> unlist()
 #'
 #' tf_crosscor(x, -x)
 #' tf_crosscov(x, x) == tf_fvar(x)

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -57,7 +57,7 @@ tf_interpolate.tfb <- function(object, arg, ...) {
   if (is.list(arg)) arg <- arg[[1]]
   attr(object, "arg") <- arg
   attr(object, "basis_matrix") <- attr(object, "basis")(arg)
-  return(object)
+  object
 }
 
 #' @export

--- a/R/methods.R
+++ b/R/methods.R
@@ -184,8 +184,9 @@ tf_basis <- function(f, as_tfd = FALSE) {
          call. = FALSE)
   }
   if (length(ensure_list(value)) != 1) {
-    stop(paste("can't assign irregular argument list to ", class(x)[1]),
-         call. = FALSE)
+    stop(
+      "can't assign irregular argument list to ", class(x)[1],
+      call. = FALSE)
   }
 
   attr(x, "arg") <- ensure_list(value)

--- a/R/ops.R
+++ b/R/ops.R
@@ -148,9 +148,8 @@ Ops.tfd <- function(e1, e2) {
     if (is_tfd(e1) && is_tfd(e2)) {
       if (.Generic == "^") {
         stop("^ not defined for \"tfd\" objects", call. = FALSE)
-      } else {
-        return(fun_op(e1, e2, .Generic))
       }
+      return(fun_op(e1, e2, .Generic))
     }
     if (is.logical(e1)) e1 <- as.numeric(e1)
     if (is.logical(e2)) e2 <- as.numeric(e2)
@@ -182,27 +181,26 @@ Ops.tfb <- function(e1, e2) {
     if (both_funs && .Generic %in% c("+", "-")) {
       # just add/subtract coefs for identical bases
       return(fun_op(e1, e2, .Generic))
-    } else {
-      # ... else convert to tfd, compute, refit basis
-      if (both_funs) {
-        basis_args <- attr(e1, "basis_args")
-        eval <- fun_op(tfd(e1), tfd(e2), .Generic)
-      }
-      if (is.logical(e1)) e1 <- as.numeric(e1)
-      if (is.logical(e2)) e2 <- as.numeric(e2)
-      if (is_tfb(e1) && is.numeric(e2)) {
-        basis_args <- attr(e1, "basis_args")
-        eval <- fun_op(tfd(e1), e2, .Generic, numeric = 2)
-      }
-      if (is_tfb(e2) && is.numeric(e1)) {
-        basis_args <- attr(e2, "basis_args")
-        eval <- fun_op(e1, tfd(e2), .Generic, numeric = 1)
-      }
-      return(do.call(
-        "tfb",
-        c(list(eval), basis_args, penalized = FALSE, verbose = FALSE)
-      ))
     }
+    # ... else convert to tfd, compute, refit basis
+    if (both_funs) {
+      basis_args <- attr(e1, "basis_args")
+      eval <- fun_op(tfd(e1), tfd(e2), .Generic)
+    }
+    if (is.logical(e1)) e1 <- as.numeric(e1)
+    if (is.logical(e2)) e2 <- as.numeric(e2)
+    if (is_tfb(e1) && is.numeric(e2)) {
+      basis_args <- attr(e1, "basis_args")
+      eval <- fun_op(tfd(e1), e2, .Generic, numeric = 2)
+    }
+    if (is_tfb(e2) && is.numeric(e1)) {
+      basis_args <- attr(e2, "basis_args")
+      eval <- fun_op(e1, tfd(e2), .Generic, numeric = 1)
+    }
+    return(do.call(
+      "tfb",
+      c(list(eval), basis_args, penalized = FALSE, verbose = FALSE)
+    ))
   }
   ret
 }

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -62,10 +62,11 @@ print.tfd_reg <- function(x, n = 5, ...) {
   NextMethod()
   cat(" based on", length(tf_arg(x)), "evaluations each\n")
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
-  if (length(x)) {
-    cat(format(x[seq_len(min(n, length(x)))], ...), sep = "\n")
-    if (n < length(x)) {
-      cat(paste0("    [....]   (", length(x) - n, " not shown)\n"))
+  len <- length(x)
+  if (len > 0) {
+    cat(format(x[seq_len(min(n, len))], ...), sep = "\n")
+    if (n < len) {
+      cat(paste0("    [....]   (", len - n, " not shown)\n"))
     }
   }
   invisible(x)
@@ -77,17 +78,20 @@ print.tfd_irreg <- function(x, n = 5, ...) {
   NextMethod()
   nas <- map_lgl(tf_evaluations(x), \(x) length(x) == 1 && all(is.na(x)))
   n_evals <- tf_count(x[!nas])
-  if (length(n_evals)) {
+  if (length(n_evals) > 0) {
     cat(paste0(
       " based on ", min(n_evals), " to ", max(n_evals), " (mean: ",
       round(mean(n_evals)), ") evaluations each\n"
     ))
-  } else cat(" (irregular) \n")
+  } else {
+    cat(" (irregular) \n")
+  }
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
-  if (length(x)) {
-    cat(format(x[seq_len(min(n, length(x)))], ...), sep = "\n")
-    if (n < length(x)) {
-      cat(paste0("    [....]   (", length(x) - n, " not shown)\n"))
+  len <- length(x)
+  if (len > 0) {
+    cat(format(x[seq_len(min(n, len))], ...), sep = "\n")
+    if (n < len) {
+      cat(paste0("    [....]   (", len - n, " not shown)\n"))
     }
   }
   invisible(x)
@@ -98,10 +102,11 @@ print.tfd_irreg <- function(x, n = 5, ...) {
 print.tfb <- function(x, n = 5, ...) {
   NextMethod()
   cat(" in basis representation:\n using ", attr(x, "basis_label"), "\n")
-  if (length(x)) {
-    cat(format(x[seq_len(min(n, length(x)))], ...), sep = "\n")
-    if (n < length(x)) {
-      cat(paste0("    [....]   (", length(x) - n, " not shown)\n"))
+  len <- length(x)
+  if (len > 0) {
+    cat(format(x[seq_len(min(n, len))], ...), sep = "\n")
+    if (n < len) {
+      cat(paste0("    [....]   (", len - n, " not shown)\n"))
     }
     invisible(x)
   }

--- a/R/rebase.R
+++ b/R/rebase.R
@@ -36,7 +36,7 @@ tf_rebase.tfd.tfd <- function(object, basis_from, arg = tf_arg(basis_from), ...)
 
   default_arg <- identical(arg, tf_arg(basis_from))
 
-  if (is_irreg(basis_from) & vec_size(basis_from) != 0) {
+  if (is_irreg(basis_from) && vec_size(basis_from) != 0) {
     if (vec_size(basis_from) != vec_size(object)) {
       if (vec_size(object) != 1) {
         stop("can't rebase regular tfd with irregular tfd of incompatible size",

--- a/R/rebase.R
+++ b/R/rebase.R
@@ -36,19 +36,18 @@ tf_rebase.tfd.tfd <- function(object, basis_from, arg = tf_arg(basis_from), ...)
 
   default_arg <- identical(arg, tf_arg(basis_from))
 
-  if (is_irreg(basis_from) && vec_size(basis_from) != 0) {
-    if (vec_size(basis_from) != vec_size(object)) {
-      if (vec_size(object) != 1) {
-        stop("can't rebase regular tfd with irregular tfd of incompatible size",
-             call. = FALSE)
-      }
-      # if <object> is length 1, extrapolate it to *all* eval points of
-      # basis_from by default
-      if (default_arg) {
-        arg <- arg |> unlist() |> unique() |> sort()
-        message("using all ", length(arg), " unique time points for new arg.")
-        default_arg <- FALSE
-      }
+  if (is_irreg(basis_from) && vec_size(basis_from) != 0 &&
+        vec_size(basis_from) != vec_size(object)) {
+    if (vec_size(object) != 1) {
+      stop("can't rebase regular tfd with irregular tfd of incompatible size",
+            call. = FALSE)
+    }
+    # if <object> is length 1, extrapolate it to *all* eval points of
+    # basis_from by default
+    if (default_arg) {
+      arg <- arg |> unlist() |> unique() |> sort()
+      message("using all ", length(arg), " unique time points for new arg.")
+      default_arg <- FALSE
     }
   }
 

--- a/R/rng.R
+++ b/R/rng.R
@@ -38,9 +38,9 @@ tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"),
   if (!is.function(cov)) {
     cov <- match.arg(cov)
     f_cov <- switch(cov,
-      "wiener" = function(s, t) pmin(s, t) / scale,
-      "squareexp" = function(s, t) exp(-(s - t)^2 / scale),
-      "matern" = function(s, t) {
+      wiener = function(s, t) pmin(s, t) / scale,
+      squareexp = function(s, t) exp(-(s - t)^2 / scale),
+      matern = function(s, t) {
         r <- sqrt(2 * order) * abs(s - t) / scale
         cov <- 2^(1 - order) / gamma(order) * r^order *
           base::besselK(r, nu = order)

--- a/R/rng.R
+++ b/R/rng.R
@@ -54,11 +54,11 @@ tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"),
   }
 
   if (length(arg) == 1) {
-    assert_integerish(arg, lower = 1)
+    assert_int(arg, lower = 1)
     arg <- seq(0, 1, length.out = arg)
   }
   assert_numeric(arg, any.missing = FALSE, unique = TRUE)
-  assert_number(n, lower = 1)
+  assert_int(n, lower = 1)
   assert_number(scale, lower = 0)
   assert_number(nugget, lower = 0)
 

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -84,7 +84,7 @@ tf_smooth.tfd <- function(x,
         call. = FALSE
       )
     }
-    if (grepl("rollm", method, fixed = TRUE)) {
+    if (startsWith(method, "rollm")) {
       if (is.null(dots$k)) {
         dots$k <- ceiling(0.05 * min(tf_count(x)))
         dots$k <- dots$k + !(dots$k %% 2) # make uneven
@@ -94,8 +94,7 @@ tf_smooth.tfd <- function(x,
         if (verbose) message("setting fill = 'extend' for start/end values.")
         dots$fill <- "extend"
       }
-    }
-    if (method == "savgol") {
+    } else {
       if (is.null(dots$fl)) {
         dots$fl <- ceiling(0.15 * min(tf_count(x)))
         dots$fl <- dots$fl + !(dots$fl %% 2) # make uneven

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -77,7 +77,7 @@ tf_smooth.tfd <- function(x,
   dots <- list(...)
   # nocov start
   if (method %in% c("savgol", "rollmean", "rollmedian")) {
-    if (verbose & !is_equidist(x)) {
+    if (verbose && !is_equidist(x)) {
       warning(
         "non-equidistant arg-values in ", sQuote(deparse(substitute(x))),
         " ignored by ", method, ".",

--- a/R/soft-impute-svd.R
+++ b/R/soft-impute-svd.R
@@ -50,8 +50,10 @@ simpute_svd <- function(x, J = min(dim(x)) - 1, thresh = 1e-05, lambda = 0, maxi
   J <- min(sum(d > 0) + 1, J)
   svd.xfill <- list(u = svd.xfill$u[, seq(J)], d = d[seq(J)], v = svd.xfill$v[, seq(J)])
   if (iter == maxit) {
-    warning(paste("Incomplete-data-SVD convergence not achieved by", maxit,
-                  "iterations"), call. = FALSE)
+    warning(
+      "Incomplete-data-SVD convergence not achieved by ", maxit, " iterations",
+      call. = FALSE
+    )
   }
   svd.xfill
 }

--- a/R/soft-impute-svd.R
+++ b/R/soft-impute-svd.R
@@ -1,12 +1,12 @@
 # copied from softImpute::Frob (v 1.4-1) under GPL-2
 # original authors: Trevor Hastie <hastie@stanford.edu> and Rahul Mazumder <rahul.mazumder@gmail.com>
 frob <- function(Uold, Dsqold, Vold, U, Dsq, V) {
-  denom = sum(Dsqold^2)
-  utu = Dsq * (t(U) %*% Uold)
-  vtv = Dsqold * (t(Vold) %*% V)
-  uvprod = sum(diag(utu %*% vtv))
-  num = denom + sum(Dsq^2) - 2 * uvprod
-  num/max(denom, 1e-09)
+  denom <- sum(Dsqold^2)
+  utu <- Dsq * (t(U) %*% Uold)
+  vtv <- Dsqold * (t(Vold) %*% V)
+  uvprod <- sum(diag(utu %*% vtv))
+  num <- denom + sum(Dsq^2) - 2 * uvprod
+  num / max(denom, 1e-09)
 }
 
 # code slightly adapted and shortened from softImpute::simpute.svd.R (v 1.4-1) under GPL-2
@@ -29,7 +29,7 @@ simpute_svd <- function(x, J = min(dim(x)) - 1, thresh = 1e-05, lambda = 0, maxi
   svd.xfill <- svd(xfill)
   ratio <- 1
   iter <- 0
-  while ((ratio > thresh) & (iter < maxit)) {
+  while ((ratio > thresh) && (iter < maxit)) {
     iter <- iter + 1
     svd.old <- svd.xfill
     d <- svd.xfill$d
@@ -42,7 +42,7 @@ simpute_svd <- function(x, J = min(dim(x)) - 1, thresh = 1e-05, lambda = 0, maxi
       svd.xfill$u[, seq(J)], pmax(svd.xfill$d - lambda, 0)[seq(J)], svd.xfill$v[, seq(J)]
     )
     if (trace.it) {
-      obj <- (.5 * sum((xfill - xhat)[!xnas]^2) + lambda * sum(d)) / nz
+      obj <- (0.5 * sum((xfill - xhat)[!xnas]^2) + lambda * sum(d)) / nz
       cat(iter, ":", "obj", format(round(obj, 5)), "ratio", ratio, "\n")
     }
   }
@@ -55,5 +55,3 @@ simpute_svd <- function(x, J = min(dim(x)) - 1, thresh = 1e-05, lambda = 0, maxi
   }
   svd.xfill
 }
-
-

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -136,9 +136,7 @@ summary.tf <- function(object, ...) {
 #' @rdname tfgroupgenerics
 #' @export
 Summary.tf <- function(...) {
-  not_defined <- switch(.Generic,
-                        `all` = , `any` = TRUE, FALSE
-  )
+  not_defined <- switch(.Generic, all = , any = TRUE, FALSE)
   if (not_defined) {
     stop(sprintf("%s not defined for \"tf\" objects", .Generic))
   }

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -20,12 +20,8 @@ summarize_tf <- function(..., op = NULL, eval = FALSE) {
     if (is_irreg(funs) && !is_irreg(ret)) ret <- as.tfd_irreg(ret)
     if (!is_irreg(funs) && is_irreg(ret)) ret <- as.tfd(ret)
     return(ret)
-  } else {
-    return(do.call(tfb, c(args,
-                          penalized = FALSE, verbose = FALSE,
-                          attr(funs, "basis_args")
-    )))
   }
+  do.call(tfb, c(args, penalized = FALSE, verbose = FALSE, attr(funs, "basis_args")))
 }
 #-------------------------------------------------------------------------------
 
@@ -61,26 +57,24 @@ mean.tf <- function(x, ...) {
 #' @export
 #' @rdname tfsummaries
 median.tf <- function(x, na.rm = FALSE, depth = c("MBD", "pointwise"), ...) {
-  if (!na.rm) {
-    if (anyNA(x)) return(1 * NA * x[1])
-  } else {
-    x <- x[!is.na(x)]
+  if (!na.rm && anyNA(x)) {
+    return(1 * NA * x[1])
   }
+  x <- x[!is.na(x)]
   depth <- match.arg(depth)
   if (depth == "pointwise") {
-    summarize_tf(x, na.rm = na.rm, op = "median", eval = is_tfd(x), ...)
+    return(summarize_tf(x, na.rm = na.rm, op = "median", eval = is_tfd(x), ...))
+  }
+  tf_depths <- tf_depth(x, depth = depth)
+  med <- x[tf_depths == max(tf_depths)]
+  if (length(med) > 1) {
+    warning(
+      length(med), " observations with maximal depth, returning their mean.",
+      call. = FALSE
+    )
+    mean(med)
   } else {
-    tf_depths <- tf_depth(x, depth = depth)
-    med <- x[tf_depths == max(tf_depths)]
-    if (length(med) > 1) {
-      warning(
-        length(med), " observations with maximal depth, returning their mean.",
-        call. = FALSE
-      )
-      mean(med)
-    } else {
-      med
-    }
+    med
   }
 }
 

--- a/R/tfb-fpc-utils.R
+++ b/R/tfb-fpc-utils.R
@@ -35,9 +35,7 @@
 #' @author Trevor Hastie, Rahul Mazumder, Cheng Meng, Fabian Scheipl
 #' @references code adapted from / inspired by `mogsa::wsvd()` by Cheng Meng
 #'   and `softImpute::softImpute()` by Trevor Hastie and Rahul Mazumder.\cr
-#' `r format_bib("meng2023mogsa")`\cr
-#' `r format_bib("mazumder2010")`\cr
-#' `r format_bib("softimpute")`
+#' `r format_bib("meng2023mogsa", "mazumder2010", "softimpute")`
 #' @family tfb-class
 #' @family tfb_fpc-class
 fpc_wsvd <- function(data, arg, pve = 0.995) {
@@ -80,7 +78,7 @@ fpc_wsvd.matrix <- function(data, arg, pve = 0.995) {
   if (any(nas)) {
     # slightly smooth efunctions from incomplete data to reduce artefacts
     efunctions <- apply(efunctions, 2,
-                        \(ef) stats::lowess(x = arg, y = ef,  f = .15)$y)
+                        \(ef) stats::lowess(x = arg, y = ef,  f = 0.15)$y)
   }
   evalues <- (pc$d[1:use])^2
   scores <- .fpc_wsvd_scores(data, efunctions, mean, weights) #!!

--- a/R/tfb-fpc.R
+++ b/R/tfb-fpc.R
@@ -1,5 +1,5 @@
 new_tfb_fpc <- function(data, domain = NULL,
-                       method = NULL, basis_from = NULL, ...) {
+                        method = NULL, basis_from = NULL, ...) {
   if (all(dim(data) == 0)) {
     ret <- vctrs::new_vctr(
       data,

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -107,7 +107,7 @@ new_tfb_spline <- function(data, domain = NULL, arg = NULL,
     arg_u <- data.frame(x = arg_u$x)
     spec_object$X <- PredictMat(spec_object, data = data.frame(arg = arg_u$x))
   }
-  if (isTRUE(min(fit$pve) < .5)) {
+  if (isTRUE(min(fit$pve) < 0.5)) {
     warning(c("Fit captures <50% of input data variability for at least one function",
               " -- consider increasing no. of basis functions 'k' or decreasing penalization."),
               call. = FALSE)
@@ -126,7 +126,7 @@ new_tfb_spline <- function(data, domain = NULL, arg = NULL,
 
   basis_constructor <- smooth_spec_wrapper(spec_object)
   # sp: from fit for global/set, -1 for local smoothing/given as -1, NA for unpen
-  s_args$sp <- if ( isTRUE(list(...)$sp != -1) || global) {
+  s_args$sp <- if (isTRUE(list(...)$sp != -1) || global) {
      fit$sp[1] |> unname()
   } else ifelse(penalized, -1, NA)
   s_args <- s_args[sort(names(s_args))] # for uniform basis_label for compare_tf_attrib

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -157,7 +157,7 @@ tfd.numeric <- function(data, arg = NULL,
     arg = arg, domain = domain,
     evaluator = evaluator
   )
-  return(do.call(tfd, args))
+  do.call(tfd, args)
 }
 
 #' @description `tfd.data.frame` uses the first 3 columns of \code{data} for

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -325,15 +325,16 @@ tfd.default <- function(data, arg = NULL, domain = NULL,
 #' @rdname tfd
 #' @export
 as.tfd <- function(data, ...) UseMethod("as.tfd")
+
 #' @export
 as.tfd.default <- function(data, ...) {
   tfd(data, ...)
 }
 
-
 #' @rdname tfd
 #' @export
 as.tfd_irreg <- function(data, ...) UseMethod("as.tfd_irreg")
+
 #' @import purrr
 #' @export
 as.tfd_irreg.tfd_reg <- function(data, ...) {
@@ -344,10 +345,12 @@ as.tfd_irreg.tfd_reg <- function(data, ...) {
   class(ret)[1] <- "tfd_irreg"
   ret
 }
+
 #' @export
 as.tfd_irreg.tfd_irreg <- function(data, ...) {
   data
 }
+
 #' @export
 as.tfd_irreg.tfb <- function(data, ...) {
   tfd(data) |> as.tfd_irreg()

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -276,7 +276,7 @@ tfd.tf <- function(data, arg = NULL, domain = NULL,
     tf_evaluations(data)
   }
   nas <- map(evaluations, \(x) which(is.na(x)))
-  if (re_eval & any(lengths(nas))) {
+  if (re_eval && any(lengths(nas))) {
     evaluations <- map2(evaluations, nas, \(x, y) if (length(y)) x[-y] else x)
     # check if all NAs occur at the same args and try to make a regular tfd if so
     na_args <- map2(arg, nas, ~.x[.y])

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -279,7 +279,7 @@ tfd.tf <- function(data, arg = NULL, domain = NULL,
   if (re_eval && any(lengths(nas))) {
     evaluations <- map2(evaluations, nas, \(x, y) if (length(y)) x[-y] else x)
     # check if all NAs occur at the same args and try to make a regular tfd if so
-    na_args <- map2(arg, nas, ~.x[.y])
+    na_args <- map2(arg, nas, \(x, y) x[y])
     if (!all(duplicated(na_args)[-1])) {
       warning(
         length(unlist(nas)), " evaluations were NA, returning irregular tfd.",

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@
 find_arg <- function(data, arg) {
   if (is.null(arg)) {
     names <- dimnames(data)[[2]]
-    suppressWarnings(arg <- as.numeric(names))
+    arg <- suppressWarnings(as.numeric(names))
     if (is.null(arg) || anyNA(arg)) {
       # extract number-strings
       # will interpret separating-dashes as minus-signs, so functions may run
@@ -15,7 +15,7 @@ find_arg <- function(data, arg) {
         names
       )
       arg <- regmatches(names, arg_matches)
-      suppressWarnings(arg <- as.numeric(arg))
+      arg <- suppressWarnings(as.numeric(arg))
       if (length(unique(arg)) != dim(data)[2]) arg <- NULL
     }
     if (is.null(arg) || anyNA(arg)) {
@@ -27,7 +27,7 @@ find_arg <- function(data, arg) {
     }
   }
   if (!length(arg)) arg <- seq_len(dim(data)[2])
-  stopifnot(length(arg) == dim(data)[2], is.numeric(arg), all(!is.na(arg)))
+  stopifnot(length(arg) == dim(data)[2], is.numeric(arg), !anyNA(arg))
   list(arg)
 }
 
@@ -42,8 +42,8 @@ assert_arg <- function(arg, x, check_unique = TRUE) {
 }
 
 .assert_arg_vector <- function(arg, domain_x, check_unique) {
-  if (check_unique && (anyDuplicated(arg) > 0) ) {
-      stop("Non-unique arg-values.", call. = FALSE)
+  if (check_unique && (anyDuplicated(arg) > 0)) {
+    stop("Non-unique arg-values.", call. = FALSE)
   }
   assert_numeric(arg,
     any.missing = FALSE, unique = FALSE, sorted = TRUE,

--- a/R/utils.R
+++ b/R/utils.R
@@ -202,7 +202,7 @@ get_args <- function(args, f) {
 #' @export
 #' @family tidyfun developer tools
 ensure_list <- function(x) {
-  if (!is.list(x)) list(x) else x
+  if (is.list(x)) x else list(x)
 }
 
 #' Make syntactically valid unique names

--- a/R/vctrs-cast.R
+++ b/R/vctrs-cast.R
@@ -2,7 +2,7 @@ assert_domain_x_in_to <- function(x, to) {
   dom_x <- tf_domain(x)
   dom_to <- tf_domain(to)
   # can (try to) cast losslessly if domain of 'to' contains domain of 'x'
-  if ((dom_to[1] <= dom_x[1]) & (dom_to[2] >= dom_x[2])) {
+  if ((dom_to[1] <= dom_x[1]) && (dom_to[2] >= dom_x[2])) {
     return(TRUE)
   }
   stop_incompatible_cast(x = x, to = to, x_arg = "", to_arg = "",

--- a/R/vctrs-ptype2.R
+++ b/R/vctrs-ptype2.R
@@ -5,9 +5,9 @@ warn_tfd_cast <- function(x, y, to = class(y)[1]) {
 
 get_larger_domain <- function(x, y) {
   domains <- cbind(x = tf_domain(x), y = tf_domain(y))
-  dom_x_larger <- domains[1,1] <= domains[1,2] && domains[2,1] >= domains[2,2]
-  dom_y_larger <- domains[1,1] >= domains[1,2] && domains[2,1] <= domains[2,2]
-  if (!(dom_x_larger | dom_y_larger)) {
+  dom_x_larger <- domains[1, 1] <= domains[1, 2] && domains[2, 1] >= domains[2, 2]
+  dom_y_larger <- domains[1, 1] >= domains[1, 2] && domains[2, 1] <= domains[2, 2]
+  if (!(dom_x_larger || dom_y_larger)) {
     stop_incompatible_type(x, y, x_arg = "", y_arg = "",
                            details = "domains incompatible")
   }

--- a/R/vctrs-ptype2.R
+++ b/R/vctrs-ptype2.R
@@ -35,12 +35,11 @@ vec_ptype2.tfd_reg.tfd_reg <- function(x, y, ...) {
     # return the one with larger domain
     if (dom_ret == "x") return(x)
     if (dom_ret == "y") return(y)
-  } else {
-    # different grids--> only tfd_irreg can represent x *and* y
-    warn_tfd_cast(x, y, "tfd_irreg")
-    if (dom_ret == "x")  return(as.tfd_irreg(x))
-    if (dom_ret == "y")  return(as.tfd_irreg(y))
   }
+  # different grids--> only tfd_irreg can represent x *and* y
+  warn_tfd_cast(x, y, "tfd_irreg")
+  if (dom_ret == "x")  return(as.tfd_irreg(x))
+  if (dom_ret == "y")  return(as.tfd_irreg(y))
 }
 
 #' @name vctrs

--- a/R/where.R
+++ b/R/where.R
@@ -82,7 +82,7 @@ tf_where <- function(f, cond,
   where_at <- map_if(where_at, \(x) length(x) == 0, \(x) NA)
   if (return == "range") {
     where_at <- map(where_at, range)
-    where_at <- do.call(what = rbind, args = where_at) |>
+    where_at <- do.call(rbind, where_at) |>
       as.data.frame() |>
       setNames(c("begin", "end"))
     return(where_at)

--- a/R/where.R
+++ b/R/where.R
@@ -88,9 +88,9 @@ tf_where <- function(f, cond,
     return(where_at)
   }
   where_at <- switch(return,
-    "any"   = map_lgl(where_at, \(x) !all(is.na(x))),
-    "first" = map_dbl(where_at, min),
-    "last"  = map_dbl(where_at, max)
+    any   = map_lgl(where_at, \(x) !all(is.na(x))),
+    first = map_dbl(where_at, min),
+    last  = map_dbl(where_at, max)
   )
   where_at
 }

--- a/man/fpc_wsvd.Rd
+++ b/man/fpc_wsvd.Rd
@@ -59,10 +59,12 @@ code adapted from / inspired by \code{mogsa::wsvd()} by Cheng Meng
 and \code{softImpute::softImpute()} by Trevor Hastie and Rahul Mazumder.\cr
 Meng C (2023).
 \emph{\code{mogsa}: Multiple omics data integrative clustering and gene set analysis}.
-\url{https://bioconductor.org/packages/mogsa}.\cr
+\url{https://bioconductor.org/packages/mogsa}.
+
 Mazumder, Rahul, Hastie, Trevor, Tibshirani, Robert (2010).
 \dQuote{Spectral regularization algorithms for learning large incomplete matrices.}
-\emph{The Journal of Machine Learning Research}, \bold{11}, 2287-2322.\cr
+\emph{The Journal of Machine Learning Research}, \bold{11}, 2287-2322.
+
 Hastie T, Mazumder R (2021).
 \emph{\code{softImpute}: Matrix Completion via Iterative Soft-Thresholded SVD}.
 R package version 1.4-1, \url{https://CRAN.R-project.org/package=softImpute}.

--- a/man/functionwise.Rd
+++ b/man/functionwise.Rd
@@ -110,9 +110,9 @@ tf_fvar(x_std) == c(1, 1, 1)
 plot(x_std, col = 1:3)
 # Custom functions:
 # 80\%tiles of each function's values:
-tf_fwise(x, ~ quantile(.x$value, .8)) |> unlist()
-# minimal value of each function for t >.5
-tf_fwise(x, ~ min(.x$value[.x$arg > .5])) |> unlist()
+tf_fwise(x, ~ quantile(.x$value, 0.8)) |> unlist()
+# minimal value of each function for t > 0.5
+tf_fwise(x, ~ min(.x$value[.x$arg > 0.5])) |> unlist()
 
 tf_crosscor(x, -x)
 tf_crosscov(x, x) == tf_fvar(x)

--- a/tests/testthat/test-concatenation.R
+++ b/tests/testthat/test-concatenation.R
@@ -1,20 +1,25 @@
-x <- tf_rgp(5,  arg = 301L) |> tf_smooth() |>
-  tfd(evaluator = tf_approx_fill_extend) |> suppressMessages()
-names(x) <- letters[1:5]
+x <- suppressMessages({
+  tf_rgp(5,  arg = 301L) |>
+    tf_smooth() |>
+    tfd(evaluator = tf_approx_fill_extend) |>
+    suppressMessages() |>
+    setNames(letters[1:5])
+})
+
 l <- list(
   x = x,
   x_short = x |> tf_zoom(0.1, 0.4),
   x_short_longdom = tfd(x |> tf_zoom(0.1, 0.4), domain = tf_domain(x),
                         evaluator = tf_approx_linear),
-  x_sp = tf_sparsify(x, dropout = .1),
-  x_ir = tf_sparsify(x, dropout = .1) |> tf_jiggle(amount = .2),
+  x_sp = tf_sparsify(x, dropout = 0.1),
+  x_ir = tf_sparsify(x, dropout = 0.1) |> tf_jiggle(amount = 0.2),
   x_fake_ir = as.tfd_irreg(x |> tf_zoom(0.1, 0.4)),
   b = tfb(x, k = 45, verbose = FALSE),
-  b2 = tfb(x, k = 15, bs = "tp", sp= .1, verbose = FALSE),
+  b2 = tfb(x, k = 15, bs = "tp", sp = 0.1, verbose = FALSE),
   bu = tfb(x, k = 15, penalized = FALSE, verbose = FALSE),
   bg = tfb(x, k = 5, global = TRUE, verbose = FALSE),
   fp = tfb_fpc(x, pve = 1),
-  fp_low = tfb_fpc(x, pve = .95)
+  fp_low = tfb_fpc(x, pve = 0.95)
 )
 
 test_that("vctrs basics & concatentation work for all subclasses", {
@@ -29,7 +34,7 @@ test_that("vctrs basics & concatentation work for all subclasses", {
     )
     testthat::expect_identical(
       l[[i]],
-      c(l[[i]], l[[i]])[1:length(l[[i]])]
+      c(l[[i]], l[[i]])[seq_along(l[[i]])]
     )
   }
   expect_s3_class(

--- a/tests/testthat/test-concatenation.R
+++ b/tests/testthat/test-concatenation.R
@@ -1,10 +1,7 @@
 x <- suppressMessages({
-  tf_rgp(5,  arg = 301L) |>
-    tf_smooth() |>
-    tfd(evaluator = tf_approx_fill_extend) |>
-    suppressMessages() |>
-    setNames(letters[1:5])
+  tf_rgp(5,  arg = 301L) |> tf_smooth() |> tfd(evaluator = tf_approx_fill_extend)
 })
+names(x) <- letters[1:5]
 
 l <- list(
   x = x,

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -34,6 +34,6 @@ test_that("MBD works", {
 
 test_that("median works", {
   expect_true(is.na(median(c(na, lin))))
-  expect_true(median(c(na, lin), na.rm = TRUE) == median(lin))
+  expect_identical(median(c(na, lin), na.rm = TRUE), median(lin))
   expect_warning(median(lin[1:2]), "2 observations")
 })

--- a/tests/testthat/test-fwise.R
+++ b/tests/testthat/test-fwise.R
@@ -1,5 +1,5 @@
 test_that("fwise summaries work for tfd_reg", {
-  x <- tf_rgp(3, arg = seq(0, 5, l = 101)) #use non-unit length to verify scaling
+  x <- tf_rgp(3, arg = seq(0, 5, length.out = 101)) #use non-unit length to verify scaling
 
   x_clamp <- (x - tf_fmin(x)) / (tf_fmax(x) - tf_fmin(x))
   expect_equal(tf_fmin(x_clamp), c(0, 0, 0), ignore_attr = TRUE)
@@ -57,15 +57,15 @@ test_that("fwise summaries work for tfb_fpc", {
 
   x_clamp <- (x - tf_fmin(x)) / (tf_fmax(x) - tf_fmin(x))
   expect_equal(tf_fmin(x_clamp), c(0, 0, 0),
-               ignore_attr = TRUE, tolerance = .05) #!! uh oh
+               ignore_attr = TRUE, tolerance = 0.05) #!! uh oh
   expect_equal(tf_fmax(x_clamp), c(1, 1, 1),
-               ignore_attr = TRUE, tolerance = .05) #!! uh oh
+               ignore_attr = TRUE, tolerance = 0.05) #!! uh oh
 
   x_std <- (x - tf_fmean(x)) / tf_fsd(x)
   expect_equal(tf_fmean(x_std), c(0, 0, 0),
-               ignore_attr = TRUE, tolerance = .05) #!! uh oh
+               ignore_attr = TRUE, tolerance = 0.05) #!! uh oh
   expect_equal(tf_fsd(x_std), c(1, 1, 1),
-               ignore_attr = TRUE, tolerance = .05) #!! uh oh
+               ignore_attr = TRUE, tolerance = 0.05) #!! uh oh
 
   expect_equal(tf_crosscov(x, x),
                tf_fvar(x))

--- a/tests/testthat/test-interpolate-tfb.R
+++ b/tests/testthat/test-interpolate-tfb.R
@@ -1,24 +1,27 @@
 test_that("tf_interpolate.tfb works", {
   x <- tf_rgp(4) |> tfb() |> suppressMessages()
-  x2 <- tf_interpolate(x, arg = seq(0,1,l = 11))
-  expect_s3_class(
-      x2,
-      class = "tfb_spline")
+  x2 <- tf_interpolate(x, arg = seq(0, 1, length.out = 11))
+  expect_s3_class(x2, class = "tfb_spline")
   expect_identical(
-    x2 |> tf_interpolate(seq(0,1,l = 31)),
-    tf_interpolate(x, arg = seq(0, 1, l = 31)))
+    tf_interpolate(x2, seq(0, 1, length.out = 31)),
+    tf_interpolate(x, arg = seq(0, 1, length.out = 31))
+  )
   expect_error(
-    tf_interpolate(x, arg = seq(-1, 1, l = 3)),
-    "Assertion on 'arg' failed")
+    tf_interpolate(x, arg = seq(-1, 1, length.out = 3)),
+    "Assertion on 'arg' failed"
+  )
 })
 
 test_that("tf_interpolate.tfb_fpc works", {
   x <- tf_rgp(4) |> tfb_fpc()
-  expect_s3_class(tf_interpolate(x, arg = seq(0,1,l = 11)), "tfb_fpc")
+  expect_s3_class(tf_interpolate(x, arg = seq(0, 1, length.out = 11)), "tfb_fpc")
   expect_identical(
-    tf_interpolate(x, arg = seq(0, 1, l = 11)) |>
-      tf_interpolate(seq(0,1,l = 31)),
-    tf_interpolate(x, arg = seq(0, 1, l = 31)))
-  expect_error(tf_interpolate(x, arg = seq(-1, 1, l = 3)),
-               "Assertion on 'arg' failed")
+    tf_interpolate(x, arg = seq(0, 1, length.out = 11)) |>
+      tf_interpolate(seq(0, 1, length.out = 31)),
+    tf_interpolate(x, arg = seq(0, 1, length.out = 31))
+  )
+  expect_error(
+    tf_interpolate(x, arg = seq(-1, 1, length.out = 3)),
+    "Assertion on 'arg' failed"
+  )
 })

--- a/tests/testthat/test-rebase.R
+++ b/tests/testthat/test-rebase.R
@@ -1,18 +1,21 @@
 set.seed(11331)
-x <- tf_rgp(5,  arg = 301L) |> tf_smooth() |>
-  tfd(evaluator = tf_approx_fill_extend) |> suppressMessages()
-names(x) <- letters[1:5]
+x <- suppressMessages({
+  tf_rgp(5,  arg = 301L) |>
+    tf_smooth() |>
+    tfd(evaluator = tf_approx_fill_extend) |>
+    setNames(letters[1:5])
+})
 
 l <- list(
   x_2 = tfd(as.matrix(x), resolution = tf_resolution(x) * 2),
-  x_sp = tf_sparsify(x, dropout = .1),
-  x_ir = tf_sparsify(x, dropout = .1) |> tf_jiggle(amount = .05),
+  x_sp = tf_sparsify(x, dropout = 0.1),
+  x_ir = tf_sparsify(x, dropout = 0.1) |> tf_jiggle(amount = 0.05),
   b = tfb(x, k = 45, verbose = FALSE),
-  b2 = tfb(x, k = 15, bs = "tp", sp= .1, verbose = FALSE),
+  b2 = tfb(x, k = 15, bs = "tp", sp = 0.1, verbose = FALSE),
   bu = tfb(x, k = 15, penalized = FALSE, verbose = FALSE),
   bg = tfb(x, k = 5, global = TRUE, verbose = FALSE),
   fpc = tfb_fpc(x, pve = 1),
-  fpc_low = tfb_fpc(x, pve = .95)
+  fpc_low = tfb_fpc(x, pve = 0.95)
 )
 
 for (i in seq_along(l)) {
@@ -22,13 +25,13 @@ for (i in seq_along(l)) {
     expect_equal(
       x_rebase |> tf_evaluations(),
       l[[i]] |> tf_evaluations(),
-      tolerance = .01
+      tolerance = 0.01
     )
     expect_equal(
       x_rebase |> tf_arg(),
       l[[i]] |> tf_arg()
     )
-    expect_equal(names(x_rebase), names(x))
+    expect_named(x_rebase, names(x))
     skip_on_cran() # to avoid non-reproducible BS-error on Fedora 36 - MKL
     expect_true(
       compare_tf_attribs(x_rebase, l[[i]], check_attrib = FALSE) |> all()
@@ -45,13 +48,13 @@ b <- tfb(x, k = 45, verbose = FALSE)
 
 l <- list(
   x = x,
-  x_sp = tf_sparsify(x, dropout = .1),
-  x_ir = tf_sparsify(x, dropout = .1) |> tf_jiggle(amount = .2),
-  b2 = tfb(x, k = 15, bs = "tp", sp = .1, verbose = FALSE),
+  x_sp = tf_sparsify(x, dropout = 0.1),
+  x_ir = tf_sparsify(x, dropout = 0.1) |> tf_jiggle(amount = 0.2),
+  b2 = tfb(x, k = 15, bs = "tp", sp = 0.1, verbose = FALSE),
   bu = tfb(x, k = 15, penalized = FALSE, verbose = FALSE),
   bg = tfb(x, k = 5, global = TRUE, verbose = FALSE),
   fpc = tfb_fpc(x, pve = 1),
-  fpc_low = tfb_fpc(x, pve = .95)
+  fpc_low = tfb_fpc(x, pve = 0.95)
 )
 
 for (i in seq_along(l)) {
@@ -60,13 +63,13 @@ for (i in seq_along(l)) {
     expect_equal(
       x_rebase |> tf_evaluations(),
       l[[i]] |> tf_evaluations(),
-      tolerance = .01
+      tolerance = 0.01
     )
     expect_equal(
       x_rebase |> tf_arg(),
       l[[i]] |> tf_arg()
     )
-    expect_equal(names(x_rebase), names(x))
+    expect_named(x_rebase, names(x))
     skip_on_cran() # to avoid non-reproducible BS-error on Fedora 36 - MKL
     expect_true(
       compare_tf_attribs(x_rebase, l[[i]], check_attrib = FALSE) |> all()
@@ -76,20 +79,23 @@ for (i in seq_along(l)) {
 
 
 set.seed(1133111)
-x <- tf_rgp(5,  arg = 301L) |> tf_smooth() |>
-  tfd(evaluator = tf_approx_fill_extend) |> suppressMessages()
-names(x) <- letters[1:5]
+x <- suppressMessages({
+  tf_rgp(5,  arg = 301L) |>
+    tf_smooth() |>
+    tfd(evaluator = tf_approx_fill_extend) |>
+    setNames(letters[1:5])
+})
 fpc <- tfb_fpc(x, pve = 1)
 
 l <- list(
   x = x,
-  x_sp = tf_sparsify(x, dropout = .1),
-  x_ir = tf_sparsify(x, dropout = .1) |> tf_jiggle(amount = .2),
+  x_sp = tf_sparsify(x, dropout = 0.1),
+  x_ir = tf_sparsify(x, dropout = 0.1) |> tf_jiggle(amount = 0.2),
   b = tfb(x, k = 45, verbose = FALSE),
-  b2 = tfb(x, k = 15, bs = "tp", sp= .1, verbose = FALSE),
+  b2 = tfb(x, k = 15, bs = "tp", sp = 0.1, verbose = FALSE),
   bu = tfb(x, k = 15, penalized = FALSE, verbose = FALSE),
   bg = tfb(x, k = 5, global = TRUE, verbose = FALSE),
-  fpc_low = tfb_fpc(x, pve = .95)
+  fpc_low = tfb_fpc(x, pve = 0.95)
 )
 for (i in seq_along(l)) {
   test_that("tf_rebase.tfb_fpc preserves args & evals and transfers attributes", {
@@ -97,13 +103,13 @@ for (i in seq_along(l)) {
     expect_equal(
       x_rebase |> tf_evaluations(),
       l[[i]] |> tf_evaluations(),
-      tolerance = .01
+      tolerance = 0.01
     )
     expect_equal(
       x_rebase |> tf_arg(),
       l[[i]] |> tf_arg()
     )
-    expect_equal(names(x_rebase), names(x))
+    expect_named(x_rebase, names(x))
     skip_on_cran() # to avoid non-reproducible BS-error on Fedora 36 - MKL
     expect_true(
       compare_tf_attribs(x_rebase, l[[i]], check_attrib = FALSE) |> all()

--- a/tests/testthat/test-tfb-fpc.R
+++ b/tests/testthat/test-tfb-fpc.R
@@ -48,12 +48,12 @@ test_that("fpc_wsvd works for partially missing data", {
   expect_message(tfb_fpc(sparse), "Using softImpute") |> suppressWarnings()
   set.seed(1312)
   x <- tf_rgp(50)
-  x_sp_pc <- x |> tf_sparsify(.02) |> tfb_fpc(pve = .98) |>
+  x_sp_pc <- x |> tf_sparsify(0.02) |> tfb_fpc(pve = 0.98) |>
     suppressMessages() |> suppressWarnings()
   expect_equal(
     as.matrix(x_sp_pc, arg = tf_arg(x)),
     as.matrix(x, arg = tf_arg(x)),
-    tolerance = .1)
+    tolerance = 0.1)
 })
 
 test_that("tfb_fpc defaults work for all kinds of regular input", {

--- a/tests/testthat/test-vec-cast.R
+++ b/tests/testthat/test-vec-cast.R
@@ -6,18 +6,18 @@ l <- list(
   x_short = x |> tf_zoom(0.1, 0.4),
   x_short_longdom = tfd(x |> tf_zoom(0.1, 0.4), domain = tf_domain(x),
                         evaluator = tf_approx_linear),
-  x_sp = tf_sparsify(x, dropout = .1) |> tfd(evaluator = tf_approx_spline),
-  x_ir = tf_sparsify(x, dropout = .1) |> tf_jiggle(amount = .2) |>
+  x_sp = tf_sparsify(x, dropout = 0.1) |> tfd(evaluator = tf_approx_spline),
+  x_ir = tf_sparsify(x, dropout = 0.1) |> tf_jiggle(amount = 0.2) |>
     tfd(evaluator = tf_approx_locf),
   x_fake_ir = as.tfd_irreg(x |> tf_zoom(0.1, 0.4)),
-  x_short_sp = tf_zoom(x, 0.2, 0.7) |> tf_sparsify(dropout = .2) |>
+  x_short_sp = tf_zoom(x, 0.2, 0.7) |> tf_sparsify(dropout = 0.2) |>
     tfd(evaluator = tf_approx_none),
   b = tfb(x, k = 45, verbose = FALSE),
-  b2 = tfb(x, k = 15, bs = "tp", sp= .1, verbose = FALSE),
+  b2 = tfb(x, k = 15, bs = "tp", sp = 0.1, verbose = FALSE),
   bu = tfb(x, k = 15, penalized = FALSE, verbose = FALSE),
   bg = tfb(x, k = 5, global = TRUE, verbose = FALSE),
   fp = tfb_fpc(x, pve = 1),
-  fp_low = tfb_fpc(x, pve = .95)
+  fp_low = tfb_fpc(x, pve = 0.95)
 )
 
 expect_cast_result <- function(x, to, irreg = FALSE, ignore = 1,


### PR DESCRIPTION
@fabian-s have a look when its convenient, most the changes are already reflected in the package, i.e. mainly consistency changes

- Use a single call to `format_bib()`
- Use leading zero
- Use assignment operator
- Minor formatting
- Remove escaping of characters where not needed
- Use `expect_named()` instead of `expect_equal(names(...))`
- Use scalar logical operators 
- Use `length.out` instead `l` in `seq()` calls
- Remove redundant return (e.g. at the end of a function)
- Remove redundant else statement after return/stop calls
- Use anonymous functions instead of formula syntax