### PR TITLE
perf: let checkmate do the unique check

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -42,11 +42,8 @@ assert_arg <- function(arg, x, check_unique = TRUE) {
 }
 
 .assert_arg_vector <- function(arg, domain_x, check_unique) {
-  if (check_unique && (anyDuplicated(arg) > 0)) {
-    stop("Non-unique arg-values.", call. = FALSE)
-  }
   assert_numeric(arg,
-    any.missing = FALSE, unique = FALSE, sorted = TRUE,
+    any.missing = FALSE, unique = check_unique, sorted = TRUE,
     lower = domain_x[1], upper = domain_x[2]
   )
 }


### PR DESCRIPTION
I'm sure there was a reason, but why not let checkmate do the unique check?