### PR TITLE
refactor: use utility function for `sort(unique(x))` pattern

### DIFF
--- a/R/approx.R
+++ b/R/approx.R
@@ -2,7 +2,7 @@ zoo_wrapper <- function(f, ...) {
   #nocov start
   dots <- list(...)
   function(x, arg, evaluations) {
-    x_arg <- sort(unique(c(x, arg)))
+    x_arg <- sort_unique(c(x, arg))
     x_arg_match <- match(x_arg, arg, nomatch = length(arg) + 1)
     requested <- x_arg %in% x
     dots[[length(dots) + 1]] <- zoo(evaluations[x_arg_match], x_arg)

--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -31,7 +31,7 @@ df_2_mat <- function(data, binning = FALSE, maxbins = 1000) {
   data <- data[complete.cases(data), ]
   nobs <- n_distinct(data$id)
   newid <- as.numeric(as.factor(data$id))
-  bins <- sort(unique(data$arg))
+  bins <- sort_unique(data$arg)
   if (binning && (length(bins) > maxbins)) {
     binvalues <- seq(
       (1 - 0.001 * sign(bins[1])) * bins[1],

--- a/R/convert.R
+++ b/R/convert.R
@@ -37,7 +37,7 @@ as.matrix.tf <- function(x, arg, interpolate = FALSE, ...) {
   if (missing(arg)) {
     arg <- tf_arg(x)
     if (is_irreg(x)) {
-      arg <- arg |> unlist(use.names = FALSE) |> unique() |> sort()
+      arg <- sort_unique(arg, simplify = TRUE)
     }
   }
   if (is_tfb(x)) interpolate <- TRUE

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -60,7 +60,7 @@ plot.tf <- function(x, y, n_grid = 50, points = is_irreg(x),
   if (missing(y)) {
     arg <- prep_plotting_arg(x, n_grid)
     # irreg args need to be turned to a vector for as.matrix below:
-    if (is.list(arg)) arg <- sort(unique(unlist(arg, use.names = FALSE)))
+    if (is_irreg(x)) arg <- sort_unique(arg, simplify = TRUE)
   } else {
     arg <- y
   }
@@ -115,7 +115,7 @@ linespoints_tf <- function(x, arg, n_grid = 50, points = TRUE,
   if (missing(arg)) {
     arg <- prep_plotting_arg(x, n_grid)
     # irreg args need to be turned to a vector for as.matrix below:
-    if (is.list(arg)) arg <- sort(unique(unlist(arg, use.names = FALSE)))
+    if (is_irreg(x)) arg <- sort_unique(arg, simplify = TRUE)
   }
   m <- if (is_tfd(x)) {
     suppressWarnings(

--- a/R/rebase.R
+++ b/R/rebase.R
@@ -46,7 +46,7 @@ tf_rebase.tfd.tfd <- function(object, basis_from, arg = tf_arg(basis_from), ...)
     # if <object> is length 1, extrapolate it to *all* eval points of
     # basis_from by default
     if (default_arg) {
-      arg <- arg |> unlist(use.names = FALSE) |> unique() |> sort()
+      arg <- sort_unique(arg, simplify = TRUE)
       message("using all ", length(arg), " unique time points for new arg.")
       default_arg <- FALSE
     }

--- a/R/tfb-spline-utils.R
+++ b/R/tfb-spline-utils.R
@@ -31,7 +31,7 @@ smooth_spec_wrapper <- function(spec, deriv = 0, eps = 1e-6) {
       # make sure quadrature runs over entire range up to the new arg
       # --> have to re-use original grid
       arg_orig <- spec$Xu[spec$Xu <= max(arg)]
-      arg_interleave <- sort(unique(c(arg_orig, arg)))
+      arg_interleave <- sort_unique(c(arg_orig, arg))
       new_args <- which(arg_interleave %in% arg)
       X <- Predict.matrix(
         object = spec,

--- a/R/utils.R
+++ b/R/utils.R
@@ -222,6 +222,13 @@ na_to_0 <- function(x) {
 
 n_distinct <- function(x) length(unique(x))
 
+sort_unique <- function(x, simplify = FALSE) {
+  if (simplify) {
+    x <- unlist(x, use.names = FALSE)
+  }
+  sort(unique(x))
+}
+
 # Source: <https://github.com/mlr-org/mlr3misc/blob/main/R/format_bib.R>
 # by Michel Lang (copied here Feb 2024)
 format_bib <- function(..., bibentries = NULL, envir = parent.frame()) {

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -62,7 +62,7 @@ test_that("as.matrix.tf works", {
   )
   expect_matrix(mat, mode = "numeric", nrows = 3, ncols = 49)
   expect_identical(row.names(mat), as.character(1:3))
-  arg <- tf_arg(x_irreg) |> unlist(use.names = FALSE) |> unique() |> sort()
+  arg <- tf_arg(x_irreg) |> sort_unique(simplify = TRUE)
   expect_identical(
     colnames(mat), as.character(arg)
   )
@@ -72,7 +72,7 @@ test_that("as.matrix.tf works", {
   expect_no_warning(mat <- as.matrix(x_irreg, interpolate = TRUE))
   expect_matrix(mat, mode = "numeric", nrows = 3, ncols = 49)
   expect_identical(row.names(mat), as.character(1:3))
-  arg <- tf_arg(x_irreg) |> unlist(use.names = FALSE) |> unique() |> sort()
+  arg <- tf_arg(x_irreg) |> sort_unique(simplify = TRUE)
   expect_identical(
     colnames(mat), as.character(arg)
   )


### PR DESCRIPTION
closes: https://github.com/tidyfun/tf/issues/111

Turns it there aren't a lot of places where the pattern of the issue was used. I've adjusted it to the `sort(unique(x))` pattern with optional unlisting. Let me know if you prefer another name or in case you think this is too much abstraction