### PR TITLE
fix: allow single tfd, remove message for empty tfd constructor

### DIFF
--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -80,7 +80,7 @@ mat_2_df <- function(x, arg) {
     is.numeric(arg), length(arg) == ncol(x)
   )
 
-  id <- unique_id(rownames(x)) %||% seq_len(dim(x)[1])
+  id <- unique_id(rownames(x)) %||% seq_len(nrow(x))
   id <- ordered(id, levels = unique(id))
   df_2_df(data_frame(
     # use t(x) here so that order of vector remains unchanged...

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -123,8 +123,9 @@ format.tf <- function(x, digits = 2, nsmall = 0, width = options()$width,
     x <- head(x, n)
   }
   resolution <- get_resolution(tf_arg(x))
+  signif_arg <- abs(floor(log10(resolution)))
   str <- string_rep_tf(x,
-    signif_arg = abs(floor(log10(resolution))),
+    signif_arg = if (signif_arg == 0) 1 else signif_arg,
     digits = digits, nsmall = nsmall, ...
   )
   if (prefix) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,16 +16,20 @@ find_arg <- function(data, arg) {
       )
       arg <- regmatches(names, arg_matches)
       arg <- suppressWarnings(as.numeric(arg))
-      if (n_distinct(arg) != dim(data)[2]) arg <- NULL
+      if (n_distinct(arg) != ncol(data)) arg <- NULL
     }
     if (is.null(arg) || anyNA(arg)) {
-      cli::cli_inform("Column names not suitable as 'arg'-values. Using {.code 1:ncol(data)}.")
+      cli::cli_inform(
+        "Column names not suitable as {.arg arg} values. Using {.code seq_len(ncol(data))}."
+      )
       arg <- numeric(0)
     }
   }
-  if (!length(arg)) arg <- seq_len(dim(data)[2])
+  if (length(arg) == 0) arg <- seq_len(ncol(data))
   assert_numeric(arg, any.missing = FALSE)
-  assert_true(length(arg) == dim(data)[2])
+  if (length(arg) != ncol(data)) {
+    cli::cli_abort("{.arg arg} must have same length as {.arg data}.")
+  }
   list(arg)
 }
 

--- a/man/tfd.Rd
+++ b/man/tfd.Rd
@@ -84,7 +84,7 @@ containing evaluations or a list of 2-column matrices/data.frames with
 \code{arg} in the first and evaluations in the second column
 
 \code{tfd.default} returns class prototype when argument to tfd() is
-NULL or not a recognised class
+\code{NULL} or not a recognised class.
 }
 \details{
 \strong{\code{evaluator}}: must be the (quoted or bare) name of a


### PR DESCRIPTION
Closes: https://github.com/tidyfun/tf/issues/138

Note: Added a workaround for `abs(floor(log10(resolution)))` for integer values since I'm not sure this behaves like the desired behaviour: 

``` r
abs(floor(log10(1:100)))
#>   [1] 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
#>  [38] 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
#>  [75] 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 2
abs(floor(log10(c(0.1, 0.01, 0.001, 1.001))))
#> [1] 1 2 3 0
```

<sup>Created on 2024-11-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>