### PR TITLE
refactor: reuse checkmate assertions and move away from stopifnot

### DIFF
--- a/R/calculus.R
+++ b/R/calculus.R
@@ -177,18 +177,8 @@ tf_integrate.tfd <- function(f, arg,
   assert_arg(arg, f)
   arg <- ensure_list(arg)
   # TODO: integrate is NA whenever arg does not cover entire domain!
-  assert_numeric(lower,
-    lower = tf_domain(f)[1], upper = tf_domain(f)[2],
-    any.missing = FALSE
-  )
-  assert_numeric(upper,
-    lower = tf_domain(f)[1], upper = tf_domain(f)[2],
-    any.missing = FALSE
-  )
-  stopifnot(
-    length(lower) %in% c(1, length(f)),
-    length(upper) %in% c(1, length(f))
-  )
+  assert_limit(lower, f)
+  assert_limit(upper, f)
   limits <- cbind(lower, upper)
   if (nrow(limits) > 1) {
     if (!definite) .NotYetImplemented() # needs vd-data
@@ -227,8 +217,8 @@ tf_integrate.tfb <- function(f, arg,
     arg <- tf_arg(f)
   }
   assert_arg(arg, f)
-  assert_bound(lower, f)
-  assert_bound(upper, f)
+  assert_limit(lower, f)
+  assert_limit(upper, f)
   if (definite) {
     return(tf_integrate(tfd(f, arg = arg),
       lower = lower, upper = upper,

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -227,18 +227,8 @@ tf_integrate.tfb <- function(f, arg,
     arg <- tf_arg(f)
   }
   assert_arg(arg, f)
-  assert_numeric(lower,
-    lower = tf_domain(f)[1], upper = tf_domain(f)[2],
-    any.missing = FALSE
-  )
-  assert_numeric(upper,
-    lower = tf_domain(f)[1], upper = tf_domain(f)[2],
-    any.missing = FALSE
-  )
-  stopifnot(
-    length(lower) %in% c(1, length(f)),
-    length(upper) %in% c(1, length(f))
-  )
+  assert_bound(lower, f)
+  assert_bound(upper, f)
   if (definite) {
     return(tf_integrate(tfd(f, arg = arg),
       lower = lower, upper = upper,

--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -3,7 +3,7 @@
 # replaces functionality of tf_unnest.tf
 # turn a tf object into a data.frame evaluated on arg with cols id-arg-value
 tf_2_df <- function(tf, arg, interpolate = TRUE, ...) {
-  assert_class(tf, "tf")
+  assert_tf(tf)
   if (missing(arg)) {
     arg <- tf_arg(tf)
   }
@@ -65,20 +65,17 @@ df_2_mat <- function(data, binning = FALSE, maxbins = 1000) {
 
 df_2_df <- function(data, id = 1, arg = 2, value = 3) {
   data <- na.omit(data[, c(id, arg, value)])
-  stopifnot(
-    nrow(data) > 0,
-    is.numeric(data[[arg]]),
-    is.numeric(data[[value]])
-  )
+  assert_data_frame(data, min.rows = 1)
+  assert_numeric(data$arg)
+  assert_numeric(data$value)
   colnames(data) <- c("id", "arg", "value")
   data
 }
 
 mat_2_df <- function(x, arg) {
-  stopifnot(
-    is.numeric(x), is.matrix(x),
-    is.numeric(arg), length(arg) == ncol(x)
-  )
+  assert_matrix(x)
+  assert_numeric(arg)
+  assert_true(length(arg) == ncol(x))
 
   id <- unique_id(rownames(x)) %||% seq_len(nrow(x))
   id <- ordered(id, levels = unique(id))

--- a/R/fwise.R
+++ b/R/fwise.R
@@ -44,7 +44,7 @@ NULL
 #' tf_crosscor(x, -x)
 #' tf_crosscov(x, x) == tf_fvar(x)
 tf_fwise <- function(x, .f, arg = tf_arg(x), ...) {
-  assert_class(x, "tf")
+  assert_tf(x)
   assert_arg(arg = arg, x = x)
   x_ <- x[, arg, matrix = FALSE]
   f_map <- as_mapper(.f, ...)
@@ -93,7 +93,7 @@ tf_frange <- function(x, arg = tf_arg(x), na.rm = FALSE, finite = FALSE) {
 #' @describeIn functionwise mean of each function:
 #'   \eqn{\tfrac{1}{|T|}\int_T x_i(t) dt}
 tf_fmean <- function(x, arg = tf_arg(x)) {
-  assert_class(x, "tf")
+  assert_tf(x)
   assert_arg(arg = arg, x = x)
   x_ <- tf_interpolate(x, arg = arg)
   arg <- ensure_list(arg)
@@ -105,7 +105,7 @@ tf_fmean <- function(x, arg = tf_arg(x)) {
 #' @describeIn functionwise variance of each function:
 #'   \eqn{\tfrac{1}{|T|}\int_T (x_i(t) - \bar x(t))^2 dt}
 tf_fvar <- function(x, arg = tf_arg(x)) {
-  assert_class(x, "tf")
+  assert_tf(x)
   assert_arg(arg = arg, x = x)
   arg <- ensure_list(arg)
   length <- map_dbl(arg, max) - map_dbl(arg, min)
@@ -127,15 +127,13 @@ tf_fsd <- function(x, arg = tf_arg(x)) {
 #'   \eqn{\tfrac{1}{|T|}\int_T (x_i(t) - \bar x(t)) (y_i(t)-\bar y(t)) dt}
 tf_crosscov <- function(x, y, arg = tf_arg(x)) {
   # check same domain, arg
-  assert_class(x, "tf")
-  assert_class(y, "tf")
+  assert_tf(x)
+  assert_tf(y)
   if (length(x) != length(y) && length(x) != 1 && length(y) != 1) {
     cli::cli_abort("{.arg x} or {.arg y} must have length 1 or the same lengths.")
   }
   assert_arg(arg = arg, x = x)
-  assert_true(
-    identical(tf_domain(x), tf_domain(y))
-  )
+  assert_true(identical(tf_domain(x), tf_domain(y)))
   arg <- ensure_list(arg)
   length <- map_dbl(arg, max) - map_dbl(arg, min)
   # set up common args &

--- a/R/methods.R
+++ b/R/methods.R
@@ -77,14 +77,14 @@ tf_count.tfd_reg <- function(f) length(tf_arg(f))
 #' @rdname tfmethods
 #' @export
 tf_domain <- function(f) {
-  assert_class(f, "tf")
+  assert_tf(f)
   attr(f, "domain")
 }
 
 #' @rdname tfmethods
 #' @export
 `tf_domain<-` <- function(x, value) {
-  assert_class(x, "tf")
+  assert_tf(x)
   assert_numeric(value, any.missing = FALSE, len = 2, unique = TRUE, sorted = TRUE)
   cli::cli_warn(c(
     x = "This changes the functions' domain but not their argument values!",
@@ -99,12 +99,12 @@ tf_domain <- function(f) {
 #' @rdname tfmethods
 #' @export
 tf_evaluator <- function(f) {
-  assert_class(f, "tfd")
+  assert_tfd(f)
   attr(f, "evaluator")
 }
 
 tf_evaluator_expr <- function(f) {
-  assert_class(f, "tfd")
+  assert_tfd(f)
   attr(f, "evaluator_name") |> as.symbol()
 }
 
@@ -123,9 +123,8 @@ tf_evaluator_expr <- function(f) {
   } else {
     as_name(enexpr(value))
   }
-  stopifnot(is_tfd(x))
   evaluator <- get(value, mode = "function", envir = parent.frame())
-  assert_class(x, "tfd")
+  assert_tfd(x)
   assert_set_equal(
     names(formals(evaluator)),
     c("x", "arg", "evaluations")
@@ -143,7 +142,7 @@ tf_evaluator_expr <- function(f) {
 #'    (columns) evaluated on `tf_arg(f)` (rows).
 #' @export
 tf_basis <- function(f, as_tfd = FALSE) {
-  assert_class(f, "tfb")
+  assert_tfb(f)
   basis <- attr(f, "basis")
   if (!as_tfd) {
     return(basis)

--- a/R/rng.R
+++ b/R/rng.R
@@ -85,7 +85,7 @@ tf_rgp <- function(n, arg = 51L, cov = c("squareexp", "wiener", "matern"),
 #' @rdname tf_jiggle
 #' @family tidyfun RNG functions
 tf_jiggle <- function(f, amount = 0.4, ...) {
-  stopifnot(is_tfd(f))
+  assert_tfd(f)
   assert_number(amount, lower = 0, upper = 0.5)
   f <- as.tfd_irreg(f)
   new_args <- map(tf_arg(f), tf_jiggle_args, amount = amount)
@@ -121,7 +121,7 @@ tf_jiggle_args <- function(arg, amount) {
 #' @export
 #' @family tidyfun RNG functions
 tf_sparsify <- function(f, dropout = 0.5, ...) {
-  stopifnot(is_tf(f))
+  assert_tf(f)
   nas <- map(tf_evaluations(f), \(x) runif(length(x)) < dropout)
   tf_evals <- map2(tf_evaluations(f), nas, \(x, y) x[!y])
   tf_args <- ensure_list(tf_arg(f))

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -19,10 +19,10 @@ new_tfb_spline <- function(data, domain = NULL, arg = NULL,
     finite = TRUE, any.missing = FALSE,
     sorted = TRUE, len = 2, unique = TRUE
   )
-  stopifnot(
-    domain[1] <= min(unlist(arg_u, use.names = FALSE)),
-    domain[2] >= max(unlist(arg_u, use.names = FALSE))
-  )
+  u_args <- unlist(arg_u, use.names = FALSE)
+  if (domain[1] > min(u_args) || max(u_args) > domain[2]) {
+    cli::cli_abort("Evaluations must be inside the domain.")
+  }
 
   # explicit factor-conversion to avoid reordering:
   data$id <- factor(data$id, unique(as.character(data$id)))
@@ -30,7 +30,9 @@ new_tfb_spline <- function(data, domain = NULL, arg = NULL,
   s_args <- list(...)[names(list(...)) %in% names(formals(s))]
   if (!has_name(s_args, "bs")) s_args$bs <- "cr"
   if (s_args$bs == "ad") {
-    cli::cli_warn("Adaptive smooths with ({.code bs = 'ad'}) not implemented yet. Changing to {.code bs = 'cr'}.")
+    cli::cli_warn(
+      "Adaptive smooths with ({.code bs = 'ad'}) not implemented yet. Changing to {.code bs = 'cr'}."
+    )
     s_args$bs <- "cr"
   }
   if (!has_name(s_args, "k")) s_args$k <- min(25, nrow(arg_u))
@@ -272,9 +274,9 @@ tfb_spline.list <- function(data, arg = NULL,
                             global = FALSE,
                             verbose = TRUE, ...) {
   vectors <- map_lgl(data, is.numeric)
-  stopifnot(all(vectors) || !any(vectors))
-
-  names_data <- names(data)
+  if (any(vectors) && !all(vectors)) {
+    cli::cli_abort("{.arg data} must have the same type.")
+  }
 
   if (all(vectors)) {
     lens <- lengths(data)

--- a/R/utils.R
+++ b/R/utils.R
@@ -180,7 +180,6 @@ assert_compatible_size <- function(op, x, y) {
   }
 }
 
-
 #-------------------------------------------------------------------------------
 # misc
 
@@ -251,6 +250,28 @@ sort_unique <- function(x, simplify = FALSE) {
   }
   sort(unique(x))
 }
+
+assert_tf <- function(x) assert_class(x, "tf")
+
+assert_tfd <- function(x) assert_class(x, "tfd")
+
+assert_tfb <- function(x) assert_class(x, "tfb")
+
+check_bound <- function(x, f) {
+  domain <- tf_domain(f)
+  res <- check_numeric(x,
+    lower = domain[1], upper = domain[2], any.missing = FALSE
+  )
+  if (!isTRUE(res)) {
+    "Integration limits must be numeric and within the domain"
+  } else if (!length(x) %in% c(1, length(f))) {
+    "Integration limits must have the same length as the function"
+  } else {
+    TRUE
+  }
+}
+
+assert_bound <- makeAssertionFunction(check_bound)
 
 # Source: <https://github.com/mlr-org/mlr3misc/blob/main/R/format_bib.R>
 # by Michel Lang (copied here Feb 2024)

--- a/R/utils.R
+++ b/R/utils.R
@@ -257,7 +257,7 @@ assert_tfd <- function(x) assert_class(x, "tfd")
 
 assert_tfb <- function(x) assert_class(x, "tfb")
 
-check_bound <- function(x, f) {
+check_limit <- function(x, f) {
   domain <- tf_domain(f)
   res <- check_numeric(x,
     lower = domain[1], upper = domain[2], any.missing = FALSE
@@ -265,13 +265,13 @@ check_bound <- function(x, f) {
   if (!isTRUE(res)) {
     "Integration limits must be numeric and within the domain"
   } else if (!length(x) %in% c(1, length(f))) {
-    "Integration limits must have the same length as the function"
+    "Integration limits length must be 1 or equal to the number of functions"
   } else {
     TRUE
   }
 }
 
-assert_bound <- makeAssertionFunction(check_bound)
+assert_limit <- makeAssertionFunction(check_limit)
 
 # Source: <https://github.com/mlr-org/mlr3misc/blob/main/R/format_bib.R>
 # by Michel Lang (copied here Feb 2024)

--- a/R/utils.R
+++ b/R/utils.R
@@ -263,9 +263,9 @@ check_limit <- function(x, f) {
     lower = domain[1], upper = domain[2], any.missing = FALSE
   )
   if (!isTRUE(res)) {
-    "Integration limits must be numeric and within the domain"
+    "Integration limit must be numeric and within the domain"
   } else if (!length(x) %in% c(1, length(f))) {
-    "Integration limits length must be 1 or equal to the number of functions"
+    "Integration limit length must be 1 or equal to the number of functions"
   } else {
     TRUE
   }

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -39,7 +39,11 @@ prep_tf_zoom_args <- function(f, begin, end) {
   } else {
     regular <- FALSE
   }
-  stopifnot(length(begin) == length(end), all(begin < end))
+  if (length(begin) != length(end) || !all(begin < end)) {
+    cli::cli_abort(
+      "{.arg begin} and {.arg end} must be of same length and ordered."
+    )
+  }
   new_domain <- c(min(begin), max(end))
   list(begin = begin, end = end, dom = new_domain, regular = regular)
 }


### PR DESCRIPTION
Following changes:

- Move from `assert_class(tf, "tf")` to `assert_tf(x)` pattern
- Refactor some `stopifnot()` to checkmate and cli errors
- Custom checkmate assertion for bound check