### PR TITLE
tests: remove testthat prefix in tests

### DIFF
--- a/R/convert-construct-utils.R
+++ b/R/convert-construct-utils.R
@@ -66,8 +66,8 @@ df_2_mat <- function(data, binning = FALSE, maxbins = 1000) {
 df_2_df <- function(data, id = 1, arg = 2, value = 3) {
   data <- na.omit(data[, c(id, arg, value)])
   assert_data_frame(data, min.rows = 1)
-  assert_numeric(data$arg)
-  assert_numeric(data$value)
+  assert_numeric(data[[arg]])
+  assert_numeric(data[[value]])
   colnames(data) <- c("id", "arg", "value")
   data
 }

--- a/tests/testthat/test-concatenation.R
+++ b/tests/testthat/test-concatenation.R
@@ -21,15 +21,15 @@ l <- list(
 
 test_that("vctrs basics & concatentation work for all subclasses", {
   for (i in seq_along(l)) {
-    testthat::expect_identical(
+    expect_identical(
       l[[i]],
       vec_restore(vec_proxy(l[[i]]), vec_ptype(l[[i]]))
     )
-    testthat::expect_identical(
+    expect_identical(
       vec_ptype2(l[[i]], l[[i]]),
       vec_ptype(l[[i]])
     )
-    testthat::expect_identical(
+    expect_identical(
       l[[i]],
       c(l[[i]], l[[i]])[seq_along(l[[i]])]
     )


### PR DESCRIPTION
- remove testthat prefix in tests
- move back to positional column assertion for more flexibility 