### PR TITLE
refactor: use `cli::cli_inform()` instead of `cli::cli_alert_*()`

### DIFF
--- a/R/calculus.R
+++ b/R/calculus.R
@@ -67,7 +67,7 @@ tf_derive.tfd <- function(f, arg, order = 1, ...) {
   # (slightly), for now. this is necessary so that we don't get NAs when trying
   # to evaluate derivs over their default domain etc.
   if (is_irreg(f)) {
-    cli::cli_alert_danger("Differentiating over irregular grids can be unstable.")
+    cli::cli_inform(c(x = "Differentiating over irregular grids can be unstable."))
   }
   assert_count(order)
   data <- as.matrix(f, arg, interpolate = TRUE)

--- a/R/depth.R
+++ b/R/depth.R
@@ -104,7 +104,7 @@ quantile.tf <- function(x, probs = seq(0, 1, 0.25), na.rm = FALSE,
   # cf. Serfling, R., & Wijesuriya, U. (2017).
   # Depth-based nonparametric description of functional data,
   #   with emphasis on use of spatial depth.
-  cli::cli_alert_info("Only pointwise, non-functional quantiles implemented for {.cls tf}s.")
+  cli::cli_inform(c(i = "Only pointwise, non-functional quantiles implemented for {.cls tf}s."))
   summarize_tf(x,
                probs = probs, na.rm = na.rm, names = names,
                type = type, op = "quantile", eval = is_tfd(x), ...

--- a/R/ops.R
+++ b/R/ops.R
@@ -222,9 +222,9 @@ tfd_op_tfd <- function(op, x, y) {
   ret <- map2(x_, y_, \(x, y) do.call(op, list(x, y)))
 
   if (attr(x, "evaluator_name") != attr(y, "evaluator_name")) {
-    cli::cli_alert_danger(
-      "Inputs have different evaluators, result has {.val {attr_ret$evaluator_name}}."
-    )
+    cli::cli_inform(c(
+      x = "Inputs have different evaluators, result has {.val {attr_ret$evaluator_name}}."
+    ))
   }
   if ("tfd_irreg" %in% attr_ret$class) {
     ret <- map2(arg_ret, ret, \(x, y) list(arg = x, value = y))

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -34,10 +34,11 @@ tf_smooth <- function(x, ...) {
 #' @rdname tf_smooth
 tf_smooth.tfb <- function(x, verbose = TRUE, ...) {
   if (verbose) {
-    cli::cli_alert_warning(
-      "You called {.fn tf_smooth} on a {.cls tfb} object, not on a {.cls tfd} object --
-       just use a smaller basis or stronger penalization.")
-    cli::cli_alert_info("Returning unchanged {.cls tfb} object.")
+    cli::cli_inform(c(
+      `!` = "You called {.fn tf_smooth} on a {.cls tfb} object, not on a {.cls tfd} object --
+       just use a smaller basis or stronger penalization.",
+      i = "Returning unchanged {.cls tfb} object."
+    ))
   }
   x
 }
@@ -75,7 +76,7 @@ tf_smooth.tfd <- function(x,
   # nocov start
   if (method %in% c("savgol", "rollmean", "rollmedian")) {
     if (verbose && !is_equidist(x)) {
-      cli::cli_alert_danger("Non-equidistant arg-values in {.arg x} ignored by {.val {method}}.")
+      cli::cli_inform(c(x = "Non-equidistant arg-values in {.arg x} ignored by {.val {method}}."))
     }
     if (startsWith(method, "rollm")) {
       if (is.null(dots$k)) {

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -68,7 +68,7 @@ median.tf <- function(x, na.rm = FALSE, depth = c("MBD", "pointwise"), ...) {
   tf_depths <- tf_depth(x, depth = depth)
   med <- x[tf_depths == max(tf_depths)]
   if (length(med) > 1) {
-    cli::cli_alert_danger("{length(med)} observations with maximal depth, returning their mean.")
+    cli::cli_inform(c(x = "{length(med)} observations with maximal depth, returning their mean."))
     mean(med)
   } else {
     med

--- a/R/tfb-fpc-utils.R
+++ b/R/tfb-fpc-utils.R
@@ -62,7 +62,7 @@ fpc_wsvd.matrix <- function(data, arg, pve = 0.995) {
   } else {
     cli::cli_inform("Using softImpute SVD on {round(mean(nas) * 100, 1)}% missing data.")
     if (pve + mean(nas) > 1) {
-      cli::cli_alert_danger("High {.arg pve} combined with high missingness likely to yield bad FPC estimates.")
+      cli::cli_inform(c(x = "High {.arg pve} combined with high missingness likely to yield bad FPC estimates."))
     }
     simpute_svd(data_wc)
   }

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -83,7 +83,7 @@ tf_zoom.tfb <- function(f, begin = tf_domain(f)[1], end = tf_domain(f)[2],
                         ...) {
   args <- prep_tf_zoom_args(f, begin, end)
   if (!args$regular) {
-    cli::cli_alert_danger("{.fn tf_zoom} was called with varying start or end points - converting to {.code tfd}.")
+    cli::cli_inform(c(x = "{.fn tf_zoom} was called with varying start or end points - converting to {.code tfd}."))
     return(tf_zoom(tfd(f), begin, end))
   }
   use <- tf_arg(f) >= args$dom[1] & tf_arg(f) <= args$dom[2]


### PR DESCRIPTION
In r-lib and tidyverse its recommended to use `cli::cli_inform()` instead of `cli::cli_alert_*()`, since thats the modern version and the same formatting can be achieved, see the .lintr from devtools for example: <https://github.com/r-lib/devtools/blob/main/.lintr.R>

See a full list of supported syntax: https://cli.r-lib.org/reference/cli_bullets.html?q=%22v%22#details