### PR TITLE
perf: set recursive to false since always dealing with depth 2

### DIFF
--- a/R/brackets.R
+++ b/R/brackets.R
@@ -83,7 +83,7 @@
   evals <- tf_evaluate(x, arg = j)
   if (!interpolate) {
     new_j <- map2(j, ensure_list(tf_arg(x)), \(x, y) !(x %in% y))
-    if (any(unlist(new_j, use.names = FALSE))) {
+    if (any(unlist(new_j, recursive = FALSE, use.names = FALSE))) {
       cli::cli_warn(c(
         i = "{.code interpolate = FALSE} & no values present for some {.arg j}",
         x = "{.code NA}s created."
@@ -95,7 +95,7 @@
 
   if (matrix) {
     ret <- do.call(rbind, evals)
-    j <- unlist(j, use.names = FALSE)
+    j <- unlist(j, recursive = FALSE, use.names = FALSE)
     colnames(ret) <- j
     rownames(ret) <- names(x)
     return(structure(ret, arg = j))

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -51,7 +51,7 @@ tf_derive.default <- function(f, arg, order = 1, ...) .NotYetImplemented()
 #' @export
 #' @describeIn tf_derive row-wise finite differences
 tf_derive.matrix <- function(f, arg, order = 1, ...) {
-  if (missing(arg)) arg <- unlist(find_arg(f), use.names = FALSE)
+  if (missing(arg)) arg <- unlist(find_arg(f), recursive = FALSE, use.names = FALSE)
   assert_numeric(arg,
     any.missing = FALSE, finite = TRUE, len = ncol(f),
     sorted = TRUE, unique = TRUE
@@ -196,7 +196,9 @@ tf_integrate.tfd <- function(f, arg,
     data_list <- map(quads, cumsum)
     names(data_list) <- names(f)
     tfd(
-      data = data_list, arg = unlist(arg, use.names = FALSE), domain = as.numeric(limits),
+      data = data_list,
+      arg = unlist(arg, recursive = FALSE, use.names = FALSE),
+      domain = as.numeric(limits),
       evaluator = !!attr(f, "evaluator_name")
     )
   }

--- a/R/depth.R
+++ b/R/depth.R
@@ -30,7 +30,7 @@ tf_depth <- function(x, arg, depth = "MBD", na.rm = TRUE, ...) {
 #' @export
 #' @rdname tf_depth
 tf_depth.matrix <- function(x, arg, depth = c("MBD", "MEI"), na.rm = TRUE, ...) {
-  if (missing(arg)) arg <- unlist(find_arg(x, arg = NULL), use.names = FALSE)
+  if (missing(arg)) arg <- unlist(find_arg(x, arg = NULL), recursive = FALSE, use.names = FALSE)
   assert_numeric(arg, finite = TRUE, any.missing = FALSE, len = ncol(x),
                  unique = TRUE, sorted = TRUE)
 

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -73,7 +73,7 @@ tf_evaluate.tfb <- function(object, arg, ...) {
   arg <- ensure_list(arg)
   assert_arg(arg, object, check_unique = FALSE)
   if (length(arg) == 1) {
-    arg <- unlist(arg, use.names = FALSE)
+    arg <- unlist(arg, recursive = FALSE, use.names = FALSE)
     evals <- evaluate_tfb_once(
       x = arg,
       arg = tf_arg(object),

--- a/R/fwise.R
+++ b/R/fwise.R
@@ -58,7 +58,7 @@ tf_fwise <- function(x, .f, arg = tf_arg(x), ...) {
 tf_fmax <- function(x, arg = tf_arg(x), na.rm = FALSE) {
   x |>
     tf_fwise(\(.x) max(.x$value, na.rm = na.rm), arg = arg) |>
-    unlist(use.names = FALSE) |>
+    unlist(recursive = FALSE, use.names = FALSE) |>
     setNames(names(x))
 }
 
@@ -68,7 +68,7 @@ tf_fmax <- function(x, arg = tf_arg(x), na.rm = FALSE) {
 tf_fmin <- function(x, arg = tf_arg(x), na.rm = FALSE) {
   x |>
     tf_fwise(\(.x) min(.x$value, na.rm = na.rm), arg = arg) |>
-    unlist(use.names = FALSE) |>
+    unlist(recursive = FALSE, use.names = FALSE) |>
     setNames(names(x))
 }
 
@@ -78,7 +78,7 @@ tf_fmin <- function(x, arg = tf_arg(x), na.rm = FALSE) {
 tf_fmedian <- function(x, arg = tf_arg(x), na.rm = FALSE) {
   x |>
     tf_fwise(\(.x) median(.x$value, na.rm = na.rm), arg = arg) |>
-    unlist(use.names = FALSE) |>
+    unlist(recursive = FALSE, use.names = FALSE) |>
     setNames(names(x))
 }
 

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -7,18 +7,17 @@
 #' @export
 #' @family tidyfun developer tools
 prep_plotting_arg <- function(f, n_grid) {
+  arg <- tf_arg(f)
   if (!isTRUE(n_grid > 1)) {
-    tf_arg(f)
-  } else {
-    resolution <- get_resolution(tf_arg(f))
-    seq(tf_domain(f)[1], tf_domain(f)[2], length.out = n_grid) |>
-      round_resolution(resolution) |>
-      setdiff(
-        round_resolution(unlist(tf_arg(f), use.names = FALSE), resolution)
-      ) |>
-      union(unlist(tf_arg(f), use.names = FALSE)) |>
-      sort()
+    return(arg)
   }
+  resolution <- get_resolution(arg)
+  arg <- unlist(arg, recursive = FALSE, use.names = FALSE)
+  seq(tf_domain(f)[1], tf_domain(f)[2], length.out = n_grid) |>
+    round_resolution(resolution) |>
+    setdiff(round_resolution(arg, resolution)) |>
+    union(arg) |>
+    sort()
 }
 
 #' `base` plots for `tf`s

--- a/R/methods.R
+++ b/R/methods.R
@@ -178,7 +178,7 @@ tf_basis <- function(f, as_tfd = FALSE) {
 #' @export
 `tf_arg<-.tfd_reg` <- function(x, value) {
   assert_arg(value, x, check_unique = FALSE)
-  if (!(length(unlist(value, use.names = FALSE)) == length(tf_arg(x)))) {
+  if (length(unlist(value, recursive = FALSE, use.names = FALSE)) != length(tf_arg(x))) {
     cli::cli_abort(
       "{.code length(arg)} not the same as original -- use {.fn tf_interpolate}."
     )

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -18,10 +18,10 @@ string_rep_tf <- function(f, signif_arg = NULL,
     tf_evaluations(f), show,
     \(x, y) do.call(format, c(format_args, list(x = x[1:y])))
   )
-  arg_nchar <- unlist(arg_ch, use.names = FALSE) |>
+  arg_nchar <- unlist(arg_ch, recursive = FALSE, use.names = FALSE) |>
     nchar() |>
     max()
-  value_nchar <- unlist(value_ch, use.names = FALSE) |>
+  value_nchar <- unlist(value_ch, recursive = FALSE, use.names = FALSE) |>
     nchar() |>
     max()
   # left-pad with spaces:
@@ -138,7 +138,7 @@ format.tf <- function(x, digits = 2, nsmall = 0, width = options()$width,
   }
   unlist(map_if(
     str, \(x) nchar(x) > width, \(x) paste0(substr(x, 1, width - 3), "...")
-  ), use.names = FALSE)
+  ), recursive = FALSE, use.names = FALSE)
 }
 
 # dynamically exported in zzz.R:

--- a/R/tfb-fpc.R
+++ b/R/tfb-fpc.R
@@ -12,7 +12,7 @@ new_tfb_fpc <- function(data, domain = NULL,
   if (!is.null(method) && !is.null(basis_from)) {
     cli::cli_abort("Can't specify both {.arg method} *and* {.arg basis_from} for {.fn new_tfb_fpc}.")
   }
-  arg <- uniquecombs(data$arg, ordered = TRUE) |> unlist(use.names = FALSE)
+  arg <- uniquecombs(data$arg, ordered = TRUE) |> unlist(recursive = FALSE, use.names = FALSE)
 
   domain <- domain %||% range(arg)
   if (!isTRUE(all.equal(domain, range(arg)))) {
@@ -166,7 +166,7 @@ tfb_fpc.data.frame <- function(data, id = 1, arg = 2, value = 3,
 #' @export
 tfb_fpc.matrix <- function(data, arg = NULL, domain = NULL,
                            method = fpc_wsvd, ...) {
-  arg <- unlist(find_arg(data, arg), use.names = FALSE)
+  arg <- unlist(find_arg(data, arg), recursive = FALSE, use.names = FALSE)
   names_data <- rownames(data)
   data <- mat_2_df(data, arg)
   ret <- new_tfb_fpc(data, domain = domain, method = method, ...)

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -19,7 +19,7 @@ new_tfb_spline <- function(data, domain = NULL, arg = NULL,
     finite = TRUE, any.missing = FALSE,
     sorted = TRUE, len = 2, unique = TRUE
   )
-  u_args <- unlist(arg_u, use.names = FALSE)
+  u_args <- unlist(arg_u, recursive = FALSE, use.names = FALSE)
   if (domain[1] > min(u_args) || max(u_args) > domain[2]) {
     cli::cli_abort("Evaluations must be inside the domain.")
   }
@@ -242,7 +242,7 @@ tfb_spline.matrix <- function(data, arg = NULL,
                               domain = NULL, penalized = TRUE,
                               global = FALSE,
                               verbose = TRUE, ...) {
-  if (is.null(arg)) arg <- unlist(find_arg(data, arg), use.names = FALSE)
+  if (is.null(arg)) arg <- unlist(find_arg(data, arg), recursive = FALSE, use.names = FALSE)
   names_data <- rownames(data)
 
   data <- mat_2_df(data, arg)

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -3,7 +3,7 @@ new_tfd <- function(arg = NULL, datalist = NULL, regular = TRUE,
   # FIXME: names weirdness- tfd  objects will ALWAYS be named if they were
   # created from an (intermediate) data.frame, but may be unnamed for different
   # provenance....
-  if (vec_size(datalist) == 0 || all(is.na(unlist(datalist, use.names = FALSE)))) {
+  if (vec_size(datalist) == 0 || all(is.na(unlist(datalist, recursive = FALSE, use.names = FALSE)))) {
     arg <- arg %||% list(numeric())
     domain <- domain %||% numeric(2)
     subclass <- if (regular) "tfd_reg" else "tfd_irreg"
@@ -35,8 +35,8 @@ new_tfd <- function(arg = NULL, datalist = NULL, regular = TRUE,
     sorted = TRUE, len = 2, unique = if (vec_size(datalist) == 1) FALSE else TRUE
   )
   stopifnot(
-    domain[1] <= min(unlist(arg, use.names = FALSE)),
-    domain[2] >= max(unlist(arg, use.names = FALSE))
+    domain[1] <= min(unlist(arg, recursive = FALSE, use.names = FALSE)),
+    domain[2] >= max(unlist(arg, recursive = FALSE, use.names = FALSE))
   )
 
   if (!regular) {
@@ -262,7 +262,7 @@ tfd.tf <- function(data, arg = NULL, domain = NULL,
   } else {
     as_name(evaluator_name)
   }
-  domain <- (domain %||% unlist(arg, use.names = FALSE) %||% tf_domain(data)) |> range()
+  domain <- (domain %||% unlist(arg, recursive = FALSE, use.names = FALSE) %||% tf_domain(data)) |> range()
   re_eval <- !is.null(arg)
   arg <- ensure_list(arg %||% tf_arg(data))
   evaluations <- if (re_eval) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -246,7 +246,7 @@ n_distinct <- function(x) length(unique(x))
 
 sort_unique <- function(x, simplify = FALSE) {
   if (simplify) {
-    x <- unlist(x, use.names = FALSE)
+    x <- unlist(x, recursive = FALSE, use.names = FALSE)
   }
   sort(unique(x))
 }

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -27,7 +27,9 @@ test_that("as.data.frame.tf works", {
   expect_named(df, c("id", "arg", "value"))
   expect_identical(df$id, as.factor(rep(1:3, each = 51)))
   expect_identical(df$arg, rep(seq(0, 1, by = 0.02), 3))
-  expect_identical(df$value, unlist(tf_evaluations(x), use.names = FALSE))
+  expect_identical(
+    df$value, unlist(tf_evaluations(x), recursive = FALSE, use.names = FALSE)
+  )
   expect_identical(as.data.frame(df), df)
 
   x <- tf_sparsify(x)
@@ -38,8 +40,10 @@ test_that("as.data.frame.tf works", {
   )
   expect_named(df, c("id", "arg", "value"))
   expect_factor(df$id)
-  expect_identical(df$arg, unlist(tf_arg(x), use.names = FALSE))
-  expect_identical(df$value, unlist(tf_evaluations(x), use.names = FALSE))
+  expect_identical(df$arg, unlist(tf_arg(x), recursive = FALSE, use.names = FALSE))
+  expect_identical(
+    df$value, unlist(tf_evaluations(x), recursive = FALSE, use.names = FALSE)
+  )
   expect_identical(as.data.frame(df), df)
 })
 


### PR DESCRIPTION
Since arg and evaluations are always max depth of two, we can set recursive to false.
Minor optimization, but a free-lunch:

``` r
x <- tf::tf_rgp(1e5, 100) |> tf::tf_sparsify() |> tf::tf_arg()
bench::mark(
  unlist(x, use.names = FALSE),
  unlist(x, recursive = FALSE, use.names = FALSE)
)
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                          <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 unlist(x, use.names = FALSE)        14.9ms 15.1ms      66.2    38.1MB    99.2 
#> 2 unlist(x, recursive = FALSE, use.n… 13.8ms 14.7ms      68.3    38.1MB     4.55
```

<sup>Created on 2024-12-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>