### PR TITLE
refactor: move asserts to own file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Collate:
     'approx.R'
+    'assertions.R'
     'bibentries.R'
     'brackets.R'
     'calculus.R'

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -1,0 +1,87 @@
+assert_domain_x_in_to <- function(x, to) {
+  dom_x <- tf_domain(x)
+  dom_to <- tf_domain(to)
+  # can (try to) cast losslessly if domain of 'to' contains domain of 'x'
+  if (dom_to[1] <= dom_x[1] && dom_to[2] >= dom_x[2]) {
+    return(TRUE)
+  }
+  stop_incompatible_cast(
+    x = x,
+    to = to,
+    x_arg = "",
+    to_arg = "",
+    details = "domains not compatible"
+  )
+}
+
+assert_same_domains <- function(x, to) {
+  if (all(tf_domain(x) == tf_domain(to))) {
+    return(TRUE)
+  }
+  stop_incompatible_cast(
+    x = x,
+    to = to,
+    x_arg = "",
+    to_arg = "",
+    details = "domains not identical"
+  )
+}
+
+assert_arg <- function(arg, x, check_unique = TRUE) {
+  if (is.list(arg)) {
+    assert_true(length(arg) %in% c(1, length(x)))
+    walk(arg, \(arg) assert_arg_vector(arg, x = x, check_unique = check_unique))
+  } else {
+    assert_arg_vector(arg, x, check_unique = check_unique)
+  }
+}
+
+assert_arg_vector <- function(arg, x, check_unique = TRUE) {
+  domain_x <- tf_domain(x)
+  assert_numeric(
+    arg,
+    any.missing = FALSE,
+    unique = check_unique,
+    sorted = TRUE,
+    lower = domain_x[1],
+    upper = domain_x[2]
+  )
+}
+
+assert_compatible_size <- function(op, x, y) {
+  x_size <- vec_size(x)
+  y_size <- vec_size(y)
+  if (!(x_size == y_size || 1 %in% c(x_size, y_size))) {
+    message <- cli::format_inline(
+      "incompatible vector sizes in {.cls {vec_ptype_full(x)}}[1:{x_size}] {op} ",
+      "{.cls {vec_ptype_full(y)}}[1:{y_size}] --",
+      "\n{{tf}} does not recycle arguments."
+    )
+    stop_incompatible_op(op, x, y, message = message)
+  }
+}
+
+assert_tf <- function(x) assert_class(x, "tf")
+
+assert_tfd <- function(x) assert_class(x, "tfd")
+
+assert_tfb <- function(x) assert_class(x, "tfb")
+
+check_limit <- function(x, f) {
+  domain <- tf_domain(f)
+  res <- check_numeric(
+    x,
+    lower = domain[1],
+    upper = domain[2],
+    any.missing = FALSE
+  )
+  if (!isTRUE(res)) {
+    "Integration limit must be numeric and within the domain"
+  } else if (!length(x) %in% c(1, length(f))) {
+    "Integration limit length must be 1 or equal to the number of functions"
+  } else {
+    TRUE
+  }
+}
+
+assert_limit <- makeAssertionFunction(check_limit)

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,23 +33,6 @@ find_arg <- function(data, arg) {
   list(arg)
 }
 
-assert_arg <- function(arg, x, check_unique = TRUE) {
-  if (is.list(arg)) {
-    assert_true(length(arg) %in% c(1, length(x)))
-    walk(arg, \(arg) assert_arg_vector(arg, x = x, check_unique = check_unique))
-  } else {
-    assert_arg_vector(arg, x, check_unique = check_unique)
-  }
-}
-
-assert_arg_vector <- function(arg, x, check_unique = TRUE) {
-  domain_x <- tf_domain(x)
-  assert_numeric(arg,
-                 any.missing = FALSE, unique = check_unique, sorted = TRUE,
-                 lower = domain_x[1], upper = domain_x[2]
-  )
-}
-
 # default resolution is ~ smallest observed interval/10
 # rounded down to the nearest decimal
 get_resolution <- function(arg) {
@@ -165,19 +148,6 @@ same_basis <- function(x, y) {
             check.attributes = FALSE) |> isTRUE()
 }
 
-assert_compatible_size <- function(op, x, y) {
-  x_size <- vec_size(x)
-  y_size <- vec_size(y)
-  if (!(x_size == y_size || 1 %in% c(x_size, y_size))) {
-    message <- cli::format_inline(
-      "incompatible vector sizes in {.cls {vec_ptype_full(x)}}[1:{x_size}] {op} ",
-      "{.cls {vec_ptype_full(y)}}[1:{y_size}] --",
-      "\n{{tf}} does not recycle arguments."
-    )
-    stop_incompatible_op(op, x, y, message = message)
-  }
-}
-
 #-------------------------------------------------------------------------------
 # misc
 
@@ -248,28 +218,6 @@ sort_unique <- function(x, simplify = FALSE) {
   }
   sort(unique(x))
 }
-
-assert_tf <- function(x) assert_class(x, "tf")
-
-assert_tfd <- function(x) assert_class(x, "tfd")
-
-assert_tfb <- function(x) assert_class(x, "tfb")
-
-check_limit <- function(x, f) {
-  domain <- tf_domain(f)
-  res <- check_numeric(x,
-    lower = domain[1], upper = domain[2], any.missing = FALSE
-  )
-  if (!isTRUE(res)) {
-    "Integration limit must be numeric and within the domain"
-  } else if (!length(x) %in% c(1, length(f))) {
-    "Integration limit length must be 1 or equal to the number of functions"
-  } else {
-    TRUE
-  }
-}
-
-assert_limit <- makeAssertionFunction(check_limit)
 
 # Source: <https://github.com/mlr-org/mlr3misc/blob/main/R/format_bib.R>
 # by Michel Lang (copied here Feb 2024)

--- a/R/vctrs-cast.R
+++ b/R/vctrs-cast.R
@@ -1,20 +1,3 @@
-assert_domain_x_in_to <- function(x, to) {
-  dom_x <- tf_domain(x)
-  dom_to <- tf_domain(to)
-  # can (try to) cast losslessly if domain of 'to' contains domain of 'x'
-  if ((dom_to[1] <= dom_x[1]) && (dom_to[2] >= dom_x[2])) {
-    return(TRUE)
-  }
-  stop_incompatible_cast(x = x, to = to, x_arg = "", to_arg = "",
-                         details = "domains not compatible")
-}
-
-assert_same_domains <- function(x, to) {
-  if (all(tf_domain(x) == tf_domain(to))) return(TRUE)
-  stop_incompatible_cast(x = x, to = to, x_arg = "", to_arg = "",
-                         details = "domains not identical")
-}
-
 same_args <- function(x, to) {
   arg_x <- tf_arg(x)
   arg_to <- tf_arg(to)


### PR DESCRIPTION
@fabian-s check if you like this, I like to organize the assertions in a separate file. We've could a couple so might be worth it.