### PR TITLE
perf: calculate curve length in single iteration

### DIFF
--- a/R/fwise.R
+++ b/R/fwise.R
@@ -97,7 +97,7 @@ tf_fmean <- function(x, arg = tf_arg(x)) {
   assert_arg(arg = arg, x = x)
   x_ <- tf_interpolate(x, arg = arg)
   arg <- ensure_list(arg)
-  length <- map_dbl(arg, max) - map_dbl(arg, min)
+  length <- map_dbl(arg, \(x) max(x) - min(x))
   tf_integrate(x_) / length
 }
 
@@ -108,7 +108,7 @@ tf_fvar <- function(x, arg = tf_arg(x)) {
   assert_tf(x)
   assert_arg(arg = arg, x = x)
   arg <- ensure_list(arg)
-  length <- map_dbl(arg, max) - map_dbl(arg, min)
+  length <- map_dbl(arg, \(x) max(x) - min(x))
   x_ <- tfd(x, arg = arg) # cast to tfd to avoid repeatedly casting back to tfb
   x_mean <- tf_interpolate(x, arg = arg) |> tf_fmean()
   x_c <- x_ - x_mean
@@ -135,7 +135,7 @@ tf_crosscov <- function(x, y, arg = tf_arg(x)) {
   assert_arg(arg = arg, x = x)
   assert_true(identical(tf_domain(x), tf_domain(y)))
   arg <- ensure_list(arg)
-  length <- map_dbl(arg, max) - map_dbl(arg, min)
+  length <- map_dbl(arg, \(x) max(x) - min(x))
   # set up common args &
   # cast to tfd to avoid repeatedly casting back to tfb
   x_ <- tfd(x, arg = arg)

--- a/R/fwise.R
+++ b/R/fwise.R
@@ -97,8 +97,8 @@ tf_fmean <- function(x, arg = tf_arg(x)) {
   assert_arg(arg = arg, x = x)
   x_ <- tf_interpolate(x, arg = arg)
   arg <- ensure_list(arg)
-  length <- map_dbl(arg, \(x) max(x) - min(x))
-  tf_integrate(x_) / length
+  len <- map_dbl(arg, \(x) max(x) - min(x))
+  tf_integrate(x_) / len
 }
 
 #' @export
@@ -108,11 +108,11 @@ tf_fvar <- function(x, arg = tf_arg(x)) {
   assert_tf(x)
   assert_arg(arg = arg, x = x)
   arg <- ensure_list(arg)
-  length <- map_dbl(arg, \(x) max(x) - min(x))
+  len <- map_dbl(arg, \(x) max(x) - min(x))
   x_ <- tfd(x, arg = arg) # cast to tfd to avoid repeatedly casting back to tfb
   x_mean <- tf_interpolate(x, arg = arg) |> tf_fmean()
   x_c <- x_ - x_mean
-  tf_integrate(x_c^2) / length
+  tf_integrate(x_c^2) / len
 }
 
 #' @export
@@ -135,7 +135,7 @@ tf_crosscov <- function(x, y, arg = tf_arg(x)) {
   assert_arg(arg = arg, x = x)
   assert_true(identical(tf_domain(x), tf_domain(y)))
   arg <- ensure_list(arg)
-  length <- map_dbl(arg, \(x) max(x) - min(x))
+  len <- map_dbl(arg, \(x) max(x) - min(x))
   # set up common args &
   # cast to tfd to avoid repeatedly casting back to tfb
   x_ <- tfd(x, arg = arg)
@@ -144,7 +144,7 @@ tf_crosscov <- function(x, y, arg = tf_arg(x)) {
   y_mean <- tf_interpolate(y, arg = arg) |> tf_fmean()
   x_c <- x_ - x_mean
   y_c <- y_ - y_mean
-  tf_integrate(x_c * y_c) / length
+  tf_integrate(x_c * y_c) / len
 }
 
 #' @export


### PR DESCRIPTION
use a single iteration for calculating curve length, somewhat suprised the memory went up:

``` r
args <- list(runif(100), runif(100), runif(100), runif(100), runif(100))
bench::mark(
  old = purrr::map_dbl(args, max) - purrr::map_dbl(args, min),
  new = purrr::map_dbl(args, \(x) max(x) - min(x))
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old          89.7µs     92µs    10497.    1.55MB     35.4
#> 2 new          12.9µs   13.4µs    73124.    3.35MB     51.2
```

<sup>Created on 2025-03-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>