### PR TITLE
chore: add air config

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,6 +8,7 @@
 ^Meta$
 ^README\.Rmd$
 ^README\.html$
+^[\.]?air\.toml$
 ^\.Renviron$
 ^\.Rproj\.user$
 ^\.ccache$


### PR DESCRIPTION
Empty air config file to signal the use of air formatter, i.e. `usethis::use_air()`