### PR TITLE
better printing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # tf 0.3.5
+* use sparklines for `print()/format()` for regular functional data
 * `tfd_irreg`-arithmetic now operates on intersection of arg-values instead of failing
   if arg-values are not identical
 * added `fda::fdSmooth` converter to `tfb`, implemented mgcv-style Fourier basis

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -46,6 +46,9 @@ tf_evaluate.tfd <- function(
   ret <- pmap(
     list(arg, ensure_list(tf_arg(object)), tf_evaluations(object)),
     function(x, y, z) {
+      if (!length(z)) {
+        return(rep(NA_real_, length(x)))
+      }
       evaluate_tfd_once(
         new_arg = x,
         arg = y,
@@ -102,6 +105,9 @@ tf_evaluate.tfb <- function(object, arg, ...) {
     ret <- pmap(
       list(arg, ensure_list(tf_arg(object)), coef(object)),
       function(x, y, z) {
+        if (!length(z) || any(is.na(z))) {
+          return(rep(NA_real_, length(x)))
+        }
         evaluate_tfb_once(
           x = x,
           arg = y,

--- a/R/methods.R
+++ b/R/methods.R
@@ -228,7 +228,7 @@ rev.tf <- function(x) {
 #' @rdname tfmethods
 #' @export
 is.na.tf <- function(x) {
-  map_lgl(unclass(x), \(x) is.na(x)[1])
+  map_lgl(unclass(x), \(x) is.na(x)[1] || is.null(x))
 }
 
 #' @rdname tfmethods

--- a/R/methods.R
+++ b/R/methods.R
@@ -228,13 +228,13 @@ rev.tf <- function(x) {
 #' @rdname tfmethods
 #' @export
 is.na.tf <- function(x) {
-  map_lgl(unclass(x), \(x) is.na(x)[1] || is.null(x))
+  map_lgl(unclass(x), \(x) is.null(x) || is.na(x)[1])
 }
 
 #' @rdname tfmethods
 #' @export
 is.na.tfd_irreg <- function(x) {
-  map_lgl(unclass(x), \(x) is.na(x$value[1]))
+  map_lgl(unclass(x), \(x) is.null(x) || is.na(x$value[1]))
 }
 
 #-------------------------------------------------------------------------------

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -41,6 +41,17 @@ string_rep_tf <- function(f, signif_arg = NULL, show = 3, digits = NULL, ...) {
   map_if(str, grepl("NULL", str, fixed = TRUE), \(x) "NA")
 }
 
+# create a spark_bar representation for x
+spark_rep_tf <- function(x, ...) {
+  evals <- tf_evaluations(x)
+  rng <- range(unlist(evals))
+  scaled <- map(evals, \(x) (x - rng[1]) / diff(rng))
+  sparks <- map(scaled, cli::spark_bar)
+  sparks[is.na(x)] <- "NA"
+  sparks
+}
+
+
 #-------------------------------------------------------------------------------
 
 #' Pretty printing and formatting for functional data
@@ -53,16 +64,22 @@ string_rep_tf <- function(f, signif_arg = NULL, show = 3, digits = NULL, ...) {
 #' @export
 #' @family tidyfun print
 print.tf <- function(x, n = 5, ...) {
+  domain <- tf_domain(x) |> sapply(format, ...)
+  range <- range(tf_evaluations(x)) |> sapply(format, ...)
   cat(paste0(
     ifelse(is_irreg(x), "irregular ", ""),
     class(x)[2],
     "[",
     length(x),
-    "] on (",
-    tf_domain(x)[1],
+    "]: [",
+    domain[1],
     ",",
-    tf_domain(x)[2],
-    ")"
+    domain[2],
+    "] -> [",
+    range[1],
+    ",",
+    range[2],
+    "]"
   ))
   invisible(x)
 }
@@ -150,13 +167,18 @@ format.tf <- function(
   }
   resolution <- get_resolution(tf_arg(x))
   signif_arg <- abs(floor(log10(resolution)))
-  str <- string_rep_tf(
-    x,
-    signif_arg = if (signif_arg == 0) 1 else signif_arg,
-    digits = digits,
-    nsmall = nsmall,
-    ...
-  )
+  if (is_irreg(x) || !cli::is_utf8_output()) {
+    str <- string_rep_tf(
+      x,
+      signif_arg = if (signif_arg == 0) 1 else signif_arg,
+      digits = digits,
+      nsmall = nsmall,
+      ...
+    )
+  } else {
+    str <- spark_rep_tf(x, ...)
+  }
+
   if (prefix) {
     prefix <- if (!is.null(names(x)) && all(nzchar(names(x), keepNA = TRUE))) {
       names(x)[seq_along(str)]

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -163,6 +163,7 @@ format.tf <- function(
 ) {
   long <- length(x) > n
   if (long && width > 0 && width <= 30) {
+    #TODO: why this?
     x <- head(x, n)
   }
   resolution <- get_resolution(tf_arg(x))
@@ -176,6 +177,8 @@ format.tf <- function(
       ...
     )
   } else {
+    #TODO: uses range of shortened vector (1:n) if called like this --
+    #  should probably determine value-range of whole vector first, then do this.
     str <- spark_rep_tf(x, ...)
   }
 

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -41,21 +41,30 @@ string_rep_tf <- function(f, signif_arg = NULL, show = 3, digits = NULL, ...) {
   map_if(str, grepl("NULL", str, fixed = TRUE), \(x) "NA")
 }
 
-# create a (binned) sparkline representation for a tfd_reg or tfb on equidistant grids
-spark_rep_tf <- function(x, bins = -1, range_x = range(unlist(evals)), ...) {
+# create a (binned) sparkline representation for a tfd_reg or tfb on
+# equidistant grids
+spark_rep_tf <- function(x, bins = -1, scale_x = range(unlist(evals))) {
   arg <- tf_arg(x)
-  if (bins < 0) {
+  gridlength <- length(arg)
+  if (bins < 0 || bins >= gridlength) {
     evals <- tf_evaluations(x)
   } else {
-    binwidth <- ceiling(length(arg) / bins)
-    new_arg <- arg[ceiling(seq(binwidth, length(arg), length = bins))]
+    binwidth <- ceiling(gridlength / bins)
+    use_index <- seq(binwidth, gridlength, length = bins) |>
+      round() |>
+      unique()
     evals <- x |>
       tf_smooth(method = "rollmean", k = binwidth, align = "right") |>
-      tfd(arg = new_arg) |>
       tf_evaluations() |>
+      map(`[`, use_index) |>
       suppressMessages()
   }
-  scaled <- map(evals, \(x) (x - range_x[1]) / diff(range_x))
+  scaled <- map(evals, function(x) {
+    ((x - scale_x[1]) / diff(scale_x)) |>
+      # avoid floating point errors that show up as gaps in sparkline:
+      pmin(1) |>
+      pmax(0)
+  })
   sparks <- map(scaled, cli::spark_bar)
   sparks[is.na(x)] <- "NA"
   sparks
@@ -102,7 +111,9 @@ print.tfd_reg <- function(x, n = 5, ...) {
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   len <- length(x)
   if (len > 0) {
-    cat(format(x[seq_len(min(n, len))], ...), sep = "\n")
+    scl_x <- range(tf_evaluations(x))
+    format(x[seq_len(min(n, len))], n = n, scale_x = scl_x, ...) |>
+      cat(sep = "\n")
     if (n < len) {
       cat(paste0("    [....]   (", len - n, " not shown)\n"))
     }
@@ -132,7 +143,8 @@ print.tfd_irreg <- function(x, n = 5, ...) {
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   len <- length(x)
   if (len > 0) {
-    cat(format(x[seq_len(min(n, len))], ...), sep = "\n")
+    format(x[seq_len(min(n, len))], n = n, ...) |>
+      cat(sep = "\n")
     if (n < len) {
       cat(paste0("    [....]   (", len - n, " not shown)\n"))
     }
@@ -147,8 +159,10 @@ print.tfb <- function(x, n = 5, ...) {
   cat(" in basis representation")
   len <- length(x)
   if (len > 0) {
+    scl_x <- range(tf_evaluations(x))
     cat(":\n using ", attr(x, "basis_label"), attr(x, "family_label"), "\n")
-    cat(format(x[seq_len(min(n, len))], ...), sep = "\n")
+    format(x[seq_len(min(n, len))], n = n, scale_x = scl_x, ...) |>
+      cat(sep = "\n")
     if (n < len) {
       cat(paste0("    [....]   (", len - n, " not shown)\n"))
     }
@@ -171,27 +185,23 @@ format.tf <- function(
   prefix = TRUE,
   ...
 ) {
-  long <- length(x) > n
-  if (long && width > 0 && width <= 30) {
-    #TODO: why this?
-    x <- head(x, n)
-  }
-  resolution <- get_resolution(tf_arg(x))
-  signif_arg <- abs(floor(log10(resolution)))
-  # TODO: right now this makes a loong string or sparkline we then shorten,
-  #  should just create the short thing in the first place in string_rep, etc...
   if (is_irreg(x) || !cli::is_utf8_output()) {
+    resolution <- get_resolution(tf_arg(x))
+    signif_arg <- abs(floor(log10(resolution)))
     str <- string_rep_tf(
-      x,
+      x[1:min(n, length(x))],
       signif_arg = if (signif_arg == 0) 1 else signif_arg,
       digits = digits,
       nsmall = nsmall,
       ...
     )
   } else {
-    #TODO: uses range of shortened vector (1:n) if called like this --
-    #  should probably determine value-range of whole vector first, then do this.
-    str <- spark_rep_tf(x, ...)
+    str <- spark_rep_tf(
+      x[1:min(n, length(x))],
+      # bins default: 5 chars to the left of sparkline for unnamed vectors
+      bins = list(...)$bins %||% (width - 5),
+      scale_x = list(...)$scale_x %||% range(tf_evaluations(x))
+    )
   }
 
   if (prefix) {
@@ -206,7 +216,6 @@ format.tf <- function(
     map_if(
       str,
       \(x) nchar(x) > width,
-      #TODO: do this in string_rep directly, don't print all (arg, val).
       \(x) paste0(substr(x, 1, width - 3), "...")
     ),
     use.names = FALSE
@@ -214,4 +223,20 @@ format.tf <- function(
 }
 
 # dynamically exported in zzz.R:
-format_glimpse.tf <- format.tf
+format_glimpse.tf <- function(
+  x,
+  digits = 2,
+  nsmall = 0,
+  n = 5,
+  prefix = TRUE,
+  ...
+) {
+  format.tf(
+    x,
+    digits = digits,
+    nsmall = nsmall,
+    n = n,
+    width = 10,
+    prefix = FALSE
+  ) #more compact by default
+}

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -79,7 +79,7 @@ spark_rep_tf <- function(f, bins = -1, scale_f = range(unlist(evals))) {
 #' give finer control.
 #'
 #' By default, `tf` objects on regular grids are shown as
-#' [sparklines](cli::spark_bar), set `sparkline = FALSE` for a text
+#' "sparklines" ([cli::spark_bar()]), set `sparkline = FALSE` for a text
 #' representation.
 #'
 #' Sparklines are based on running mean values of the function values, but

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -117,19 +117,17 @@ print.tfd_irreg <- function(x, n = 5, ...) {
 #' @export
 print.tfb <- function(x, n = 5, ...) {
   NextMethod()
-  cat(
-    " in basis representation:\n using ",
-    attr(x, "basis_label"),
-    attr(x, "family_label"),
-    "\n"
-  )
+  cat(" in basis representation")
   len <- length(x)
   if (len > 0) {
+    cat(":\n using ", attr(x, "basis_label"), attr(x, "family_label"), "\n")
     cat(format(x[seq_len(min(n, len))], ...), sep = "\n")
     if (n < len) {
       cat(paste0("    [....]   (", len - n, " not shown)\n"))
     }
     invisible(x)
+  } else {
+    cat(".\n")
   }
 }
 

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -43,30 +43,30 @@ string_rep_tf <- function(f, signif_arg = NULL, show = 3, digits = NULL, ...) {
 
 # create a (binned) sparkline representation for a tfd_reg or tfb on
 # equidistant grids
-spark_rep_tf <- function(x, bins = -1, scale_x = range(unlist(evals))) {
-  arg <- tf_arg(x)
+spark_rep_tf <- function(f, bins = -1, scale_f = range(unlist(evals))) {
+  arg <- tf_arg(f)
   gridlength <- length(arg)
   if (bins < 0 || bins >= gridlength) {
-    evals <- tf_evaluations(x)
+    evals <- tf_evaluations(f)
   } else {
     binwidth <- ceiling(gridlength / bins)
     use_index <- seq(binwidth, gridlength, length = bins) |>
       round() |>
       unique()
-    evals <- x |>
+    evals <- f |>
       tf_smooth(method = "rollmean", k = binwidth, align = "right") |>
       tf_evaluations() |>
       map(`[`, use_index) |>
       suppressMessages()
   }
   scaled <- map(evals, function(x) {
-    ((x - scale_x[1]) / diff(scale_x)) |>
+    ((x - scale_f[1]) / diff(scale_f)) |>
       # avoid floating point errors that show up as gaps in sparkline:
       pmin(1) |>
       pmax(0)
   })
   sparks <- map(scaled, cli::spark_bar)
-  sparks[is.na(x)] <- "NA"
+  sparks[is.na(f)] <- "NA"
   sparks
 }
 
@@ -75,13 +75,39 @@ spark_rep_tf <- function(x, bins = -1, scale_x = range(unlist(evals))) {
 
 #' Pretty printing and formatting for functional data
 #'
-#' Print/format `tf`-objects.
+#' Prints and formats `tf`-objects for display. See Details / examples for options that
+#' give finer control.
 #'
+#' By default, `tf` objects on regular grids are shown as
+#' [sparklines](cli::spark_bar), set `sparkline = FALSE` for a text
+#' representation.
+#'
+#' Sparklines are based on running mean values of the function values, but
+#' these don't check for non-equidistant grids, so the visual impression will be
+#' misleading for very unequal grid distances.
+#'
+#' Sparklines use
+#' `options()$width/3` bins for printing/formatting by default, use `bins`
+#' argument to set the number of bins explicitly.
+#' For [tibble::glimpse()], we use 8 bins by default for compact display.
 #' @rdname tfdisplay
-#' @param n how many elements of `x` to print out
-#' @returns prints out `x` and returns it invisibly
+#' @param n how many elements of `x` to print out at most
+#' @param ... handed over to [format.tf()]
+#' @returns **`print`**: prints out `x` and returns it invisibly
 #' @export
 #' @family tidyfun print
+#' @examples
+#' t <- seq(0, 1, l = 201)
+#' cosine <- lapply(1:4, \(i) cos(i * pi * t)) |> tfd(arg = t)
+#' cosine
+#' tf_sparsify(cosine, dropout = .8)
+#'
+#' format(cosine, sparkline = FALSE)
+#' format(cosine, bins = 5)
+#' format(cosine, bins = 40)
+#'
+#' #! very non-equidistant grids --> sparklines can mislead about actual shapes:
+#' tfd(cosine, arg = t^3)
 print.tf <- function(x, n = 5, ...) {
   domain <- tf_domain(x) |> sapply(format, ...)
   range <- range(tf_evaluations(x)) |> sapply(format, ...)
@@ -111,8 +137,8 @@ print.tfd_reg <- function(x, n = 5, ...) {
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   len <- length(x)
   if (len > 0) {
-    scl_x <- range(tf_evaluations(x))
-    format(x[seq_len(min(n, len))], n = n, scale_x = scl_x, ...) |>
+    scale_ <- range(tf_evaluations(x))
+    format(x[seq_len(min(n, len))], scale_f = scale_, prefix = TRUE, ...) |>
       cat(sep = "\n")
     if (n < len) {
       cat(paste0("    [....]   (", len - n, " not shown)\n"))
@@ -143,7 +169,7 @@ print.tfd_irreg <- function(x, n = 5, ...) {
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   len <- length(x)
   if (len > 0) {
-    format(x[seq_len(min(n, len))], n = n, ...) |>
+    format(x[seq_len(min(n, len))], prefix = TRUE, ...) |>
       cat(sep = "\n")
     if (n < len) {
       cat(paste0("    [....]   (", len - n, " not shown)\n"))
@@ -159,9 +185,9 @@ print.tfb <- function(x, n = 5, ...) {
   cat(" in basis representation")
   len <- length(x)
   if (len > 0) {
-    scl_x <- range(tf_evaluations(x))
+    scale_ <- range(tf_evaluations(x))
     cat(":\n using ", attr(x, "basis_label"), attr(x, "family_label"), "\n")
-    format(x[seq_len(min(n, len))], n = n, scale_x = scl_x, ...) |>
+    format(x[seq_len(min(n, len))], scale_f = scale_, prefix = TRUE, ...) |>
       cat(sep = "\n")
     if (n < len) {
       cat(paste0("    [....]   (", len - n, " not shown)\n"))
@@ -174,22 +200,25 @@ print.tfb <- function(x, n = 5, ...) {
 
 #' @rdname tfdisplay
 #' @inheritParams base::format.default
-#' @param prefix used internally.
+#' @param prefix prefix with names / index positions? defaults to `FALSE`
+#' @param sparkline use a sparkline representation? defaults to `TRUE`
+#'   (not available for irregular data)
+#' @returns a character representation of `x`
 #' @export
 format.tf <- function(
   x,
   digits = 2,
   nsmall = 0,
   width = options()$width,
-  n = 5,
-  prefix = TRUE,
+  sparkline = TRUE,
+  prefix = FALSE,
   ...
 ) {
-  if (is_irreg(x) || !cli::is_utf8_output()) {
+  if (is_irreg(x) || !cli::is_utf8_output() || !sparkline) {
     resolution <- get_resolution(tf_arg(x))
     signif_arg <- abs(floor(log10(resolution)))
     str <- string_rep_tf(
-      x[1:min(n, length(x))],
+      x,
       signif_arg = if (signif_arg == 0) 1 else signif_arg,
       digits = digits,
       nsmall = nsmall,
@@ -197,10 +226,9 @@ format.tf <- function(
     )
   } else {
     str <- spark_rep_tf(
-      x[1:min(n, length(x))],
-      # bins default: 5 chars to the left of sparkline for unnamed vectors
-      bins = list(...)$bins %||% (width - 5),
-      scale_x = list(...)$scale_x %||% range(tf_evaluations(x))
+      x,
+      bins = list(...)$bins %||% floor(width / 3),
+      scale_f = list(...)$scale_f %||% range(tf_evaluations(x))
     )
   }
 
@@ -227,16 +255,15 @@ format_glimpse.tf <- function(
   x,
   digits = 2,
   nsmall = 0,
-  n = 5,
-  prefix = TRUE,
+  prefix = FALSE,
   ...
 ) {
-  format.tf(
-    x,
-    digits = digits,
-    nsmall = nsmall,
-    n = n,
-    width = 10,
-    prefix = FALSE
-  ) #more compact by default
+  dots <- list(...)
+  if (is.null(dots$bins)) {
+    dots$bins <- 8 #compact display by default
+  }
+  do.call(
+    format.tf,
+    c(list(x, digits = digits, nsmall = nsmall, prefix = FALSE), dots)
+  )
 }

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -41,11 +41,21 @@ string_rep_tf <- function(f, signif_arg = NULL, show = 3, digits = NULL, ...) {
   map_if(str, grepl("NULL", str, fixed = TRUE), \(x) "NA")
 }
 
-# create a spark_bar representation for x
-spark_rep_tf <- function(x, ...) {
-  evals <- tf_evaluations(x)
-  rng <- range(unlist(evals))
-  scaled <- map(evals, \(x) (x - rng[1]) / diff(rng))
+# create a (binned) sparkline representation for a tfd_reg or tfb on equidistant grids
+spark_rep_tf <- function(x, bins = -1, range_x = range(unlist(evals)), ...) {
+  arg <- tf_arg(x)
+  if (bins < 0) {
+    evals <- tf_evaluations(x)
+  } else {
+    binwidth <- ceiling(length(arg) / bins)
+    new_arg <- arg[ceiling(seq(binwidth, length(arg), length = bins))]
+    evals <- x |>
+      tf_smooth(method = "rollmean", k = binwidth, align = "right") |>
+      tfd(arg = new_arg) |>
+      tf_evaluations() |>
+      suppressMessages()
+  }
+  scaled <- map(evals, \(x) (x - range_x[1]) / diff(range_x))
   sparks <- map(scaled, cli::spark_bar)
   sparks[is.na(x)] <- "NA"
   sparks
@@ -168,6 +178,8 @@ format.tf <- function(
   }
   resolution <- get_resolution(tf_arg(x))
   signif_arg <- abs(floor(log10(resolution)))
+  # TODO: right now this makes a loong string or sparkline we then shorten,
+  #  should just create the short thing in the first place in string_rep, etc...
   if (is_irreg(x) || !cli::is_utf8_output()) {
     str <- string_rep_tf(
       x,
@@ -194,6 +206,7 @@ format.tf <- function(
     map_if(
       str,
       \(x) nchar(x) > width,
+      #TODO: do this in string_rep directly, don't print all (arg, val).
       \(x) paste0(substr(x, 1, width - 3), "...")
     ),
     use.names = FALSE

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -1,5 +1,5 @@
 new_tfb_spline <- function(
-  data,
+  data, # data.frame with id, arg, value
   domain = NULL,
   arg = NULL,
   penalized = TRUE,
@@ -81,11 +81,16 @@ new_tfb_spline <- function(
   ls_fit <- gam_args$family$family == "gaussian" &
     gam_args$family$link == "identity"
 
+  underdetermined <- n_evaluations <= spec_object$bs.dim
   if (!penalized) {
-    underdetermined <- n_evaluations <= spec_object$bs.dim
     if (any(underdetermined)) {
       cli::cli_abort(
-        "At least as many basis functions as evaluations for {sum(underdetermined)} functions. Use {.code penalized = TRUE} or reduce k for spline interpolation."
+        c(
+          "Can't compute spline coefficients for too sparse data: At least as many basis functions as evaluations for {sum(underdetermined)} of {vec_size(underdetermined)} entries in
+        input data.",
+          ">" = "Use {.code penalized = TRUE} or reduce {.arg k} for spline interpolation.",
+          "i" = "Affected entries: {names(n_evaluations[underdetermined])}"
+        )
       )
     }
     fit <-
@@ -98,6 +103,15 @@ new_tfb_spline <- function(
         ls_fit = ls_fit
       )
   } else {
+    if (any(underdetermined)) {
+      cli::cli_warn(
+        c(
+          "Sparse data: Spline interpolation may be unreliable/infeasible for functions with fewer evaluations than basis functions, {sum(underdetermined)} of {vec_size(underdetermined)} entries affected.",
+          ">" = "Check results and consider reducing {.arg k} for spline interpolation.",
+          "i" = "Affected entries: {names(n_evaluations[underdetermined])}"
+        )
+      )
+    }
     fit <-
       fit_penalized(
         data = data,

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -246,13 +246,15 @@ tfd.list <- function(
   ...
 ) {
   evaluator <- as_name(enexpr(evaluator))
-  vectors <- map_lgl(data, \(x) is.numeric(x) & !is.array(x))
+  vectors <- map_lgl(data, \(x) is.null(x) || (is.numeric(x) & !is.array(x)))
   if (all(vectors)) {
     where_na <- map(data, is.na)
     data <- map2(data, where_na, \(x, y) x[!y])
     lens <- lengths(data)
-    regular <- all(lens == lens[1]) &
-      (is.numeric(arg) || all(duplicated(arg)[-1])) # duplicated(NULL) == TRUE!
+    empty <- lens != 0
+    regular <- all(lens[!empty] == lens[!empty][1]) &
+      (is.numeric(arg) || all(duplicated(arg)[-1]))
+    # duplicated(NULL) == TRUE!
     if (!regular) {
       if (is.null(arg)) {
         cli::cli_abort("{.arg arg} cannot be NULL")
@@ -262,7 +264,7 @@ tfd.list <- function(
           "length of {.arg arg}-list does not match {.arg data}-list"
         )
       }
-      if (any(lengths(arg) != lengths(where_na))) {
+      if (any(lengths(arg)[!empty] != lengths(where_na)[!empty])) {
         cli::cli_abort(
           "lengths of {.arg arg}-vectors do not match lengths of {.arg data}-list entries"
         )

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -43,7 +43,7 @@ new_tfd <- function(
     any.missing = FALSE,
     sorted = TRUE,
     len = 2,
-    unique = if (vec_size(datalist) == 1) FALSE else TRUE
+    unique = TRUE
   )
   u_args <- unlist(arg, use.names = FALSE)
   if (domain[1] > min(u_args) || max(u_args) > domain[2]) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,21 +70,22 @@ round_resolution <- function(arg, resolution, updown = 0) {
   }
 }
 
-is_equidist <- function(f) {
+# grids are "equidistant" if their distances deviate less
+# than tol * resolution (by default: by less than 10%)
+is_equidist <- function(f, tol = 1) {
   if (is_irreg(f)) {
     return(FALSE)
   }
-  unique_diffs <- map_lgl(
-    ensure_list(tf_arg(f)),
+  arg <- tf_arg(f)
+  f_resolution <- get_resolution(arg) * tol
+  equidist <- map_lgl(
+    ensure_list(arg),
     function(x) {
-      round_resolution(x, attr(f, "resolution")) |>
-        diff() |>
-        duplicated() |>
-        tail(-1) |>
-        all()
+      deviate <- diff(x) |> diff() |> abs() |> max()
+      deviate < f_resolution
     }
   )
-  all(unique_diffs)
+  all(equidist)
 }
 
 # get intersection of arg vectors

--- a/attic/dev-sparklines.R
+++ b/attic/dev-sparklines.R
@@ -1,0 +1,15 @@
+options(width = 60)
+
+t <- seq(0, 1, l = 201)
+sincos <- map(1:5, \(i) cos(2 * pi * i * t)) |> tfd()
+sincos
+
+tfb(sincos)
+
+sincos |> tf_sparsify()
+
+sincos[1] <- NA
+sincos
+
+options(width = 40, digits = 2)
+sincos

--- a/attic/dev-sparklines.R
+++ b/attic/dev-sparklines.R
@@ -1,69 +1,32 @@
-library("tf")
+devtools::load_all("~/fda/tidyfun-pkgs/tf")
 options(width = 80)
 
 t <- seq(0, 1, l = 101)
-cosine <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd(arg = t)
+cosine <- purrr::map(1:5, \(i) cos(2 * pi * i * t) * i) |> tfd(arg = t)
 cosine
 
 format(cosine, sparkline = FALSE)
 format(cosine, bins = 5)
 format(cosine, bins = 40)
 
-#! very non-equidistant grids --> sparklines can mislead
-cosine_2 <- tfd(cosine, arg = t^3)
-format(cosine_2, bins = 40)
-
 
 tfb(cosine)
-
 cosine |> tf_sparsify()
 
-cosine[1] <- NA
-cosine
 
-options(width = 40)
-cosine
-
-tfb(tidyfun::dti_df$rcst[1:10])
-# if names are (too) long, rightmost edges get cut off :(
-tidyfun::chf_df$activity[1:10]
-
-
-# check: sparklines show values rel. to *global* min/max:
-min_max <- tfd(rep(1, 20)) / 2^seq(-3, 3, l = 10)
-print(min_max, n = 3)
-print(min_max, n = 10)
-print(rev(min_max), n = 3)
-
-# check: sparkline work for non-equidistant grids
-cosine_g <- tfd(cosine, arg = t^3)
+(rcst_b <- tfb(tidyfun::dti_df$rcst[1:10], verbose = FALSE))
+(act <- tidyfun::chf_df$activity)
 
 # --------
 
-options(width = 60)
-
-act <- tidyfun::chf_df$activity[1:20]
-tf:::spark_rep_tf(act[1:2], bins = 2000)
-tf:::spark_rep_tf(act[1:2], bins = 100)
-tf:::spark_rep_tf(act[1:2], bins = 50)
-tf:::spark_rep_tf(act[1:2], bins = 10)
-
-rcst_b <- tfb(
-  tidyfun::dti_df$rcst[1:10],
-  arg = seq(0, 1, l = 201),
-  bs = "ps",
-  m = c(2, 1)
-)
-plot(rcst_b[1:3], col = 1:5)
-tf:::spark_rep_tf(rcst_b[1:3], bins = 100)
-tf:::spark_rep_tf(rcst_b[1:3], bins = 30)
-
-# also looks good in glimpse / pillar:
+# also looks good in glimpse / pillar / print_tbl:
 tibble::glimpse(tidyfun::chf_df)
 tidyfun:::pillar_shaft.tf(tidyfun::chf_df$activity)
-
+tidyfun::chf_df[, 5:8]
 
 # ---------
+
+#! 2-25 times slower, still just microseconds so who cares:
 
 microbenchmark::microbenchmark(
   string = tf:::string_rep_tf(cosine),
@@ -87,11 +50,9 @@ microbenchmark::microbenchmark(
   bin100 = tf:::spark_rep_tf(rcst_b, bins = 100)
 )
 
-#------------------------------------------------------------------------------
+#-------------
 
-# working in print.tbl_df as well
-
-tibble::tibble(a = 1:10, b = tf_rgp(10, arg = 5))
-
-# but not for real data:
-tidyfun::chf_df[, 7:8]
+#! very non-equidistant grids --> sparklines can mislead
+cosine_2 <- tfd(cosine, arg = t^3)
+format(cosine_2, bins = 40)
+format(cosine, bins = 40)

--- a/attic/dev-sparklines.R
+++ b/attic/dev-sparklines.R
@@ -13,3 +13,6 @@ sincos
 
 options(width = 40, digits = 2)
 sincos
+
+tfb(tidyfun::dti_df$rcst[1:10])
+tidyfun::chf_df$activity[1:10]

--- a/attic/dev-sparklines.R
+++ b/attic/dev-sparklines.R
@@ -1,7 +1,8 @@
+library("tf")
 options(width = 60)
 
-t <- seq(0, 1, l = 201)
-sincos <- map(1:5, \(i) cos(2 * pi * i * t)) |> tfd()
+t <- seq(0, 1, l = 301)
+sincos <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd()
 sincos
 
 tfb(sincos)
@@ -16,3 +17,46 @@ sincos
 
 tfb(tidyfun::dti_df$rcst[1:10])
 tidyfun::chf_df$activity[1:10]
+
+# --------
+
+tf:::spark_rep_tf(sincos)
+tf:::spark_rep_tf(sincos, bins = 30)
+
+act <- tidyfun::chf_df$activity[1:20]
+plot(act[1:5], type = "lasagna")
+tf:::spark_rep_tf(act[1:5])
+tf:::spark_rep_tf(act[1:5], bins = 50)
+
+rcst_b <- tfb(
+  tidyfun::dti_df$rcst[1:10],
+  arg = seq(0, 1, l = 201),
+  bs = "ps",
+  m = c(2, 1)
+)
+plot(rcst_b[1:3], col = 1:5)
+tf:::spark_rep_tf(rcst_b[1:3])
+tf:::spark_rep_tf(rcst_b[1:3], bins = 30)
+
+microbenchmark::microbenchmark(
+  string = tf:::string_rep_tf(sincos),
+  nobin = tf:::spark_rep_tf(sincos),
+  bin30 = tf:::spark_rep_tf(sincos, bins = 30),
+  bin100 = tf:::spark_rep_tf(sincos, bins = 100)
+) # x1, x15
+
+
+microbenchmark::microbenchmark(
+  string = tf:::string_rep_tf(act),
+  nobin = tf:::spark_rep_tf(act),
+  bin30 = tf:::spark_rep_tf(act, bins = 30),
+  bin100 = tf:::spark_rep_tf(act, bins = 100)
+) # x6, x6
+
+
+microbenchmark::microbenchmark(
+  string = tf:::string_rep_tf(rcst_b),
+  nobin = tf:::spark_rep_tf(rcst_b),
+  bin30 = tf:::spark_rep_tf(rcst_b, bins = 30),
+  bin100 = tf:::spark_rep_tf(rcst_b, bins = 100)
+) # x10

--- a/attic/dev-sparklines.R
+++ b/attic/dev-sparklines.R
@@ -1,19 +1,28 @@
 library("tf")
 options(width = 80)
 
-t <- seq(0, 1, l = 301)
-sincos <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd(arg = t)
-sincos
+t <- seq(0, 1, l = 101)
+cosine <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd(arg = t)
+cosine
 
-tfb(sincos)
+format(cosine, sparkline = FALSE)
+format(cosine, bins = 5)
+format(cosine, bins = 40)
 
-sincos |> tf_sparsify()
+#! very non-equidistant grids --> sparklines can mislead
+cosine_2 <- tfd(cosine, arg = t^3)
+format(cosine_2, bins = 40)
 
-sincos[1] <- NA
-sincos
+
+tfb(cosine)
+
+cosine |> tf_sparsify()
+
+cosine[1] <- NA
+cosine
 
 options(width = 40)
-sincos
+cosine
 
 tfb(tidyfun::dti_df$rcst[1:10])
 # if names are (too) long, rightmost edges get cut off :(
@@ -25,6 +34,9 @@ min_max <- tfd(rep(1, 20)) / 2^seq(-3, 3, l = 10)
 print(min_max, n = 3)
 print(min_max, n = 10)
 print(rev(min_max), n = 3)
+
+# check: sparkline work for non-equidistant grids
+cosine_g <- tfd(cosine, arg = t^3)
 
 # --------
 
@@ -54,10 +66,10 @@ tidyfun:::pillar_shaft.tf(tidyfun::chf_df$activity)
 # ---------
 
 microbenchmark::microbenchmark(
-  string = tf:::string_rep_tf(sincos),
-  nobin = tf:::spark_rep_tf(sincos),
-  bin30 = tf:::spark_rep_tf(sincos, bins = 30),
-  bin100 = tf:::spark_rep_tf(sincos, bins = 100)
+  string = tf:::string_rep_tf(cosine),
+  nobin = tf:::spark_rep_tf(cosine),
+  bin30 = tf:::spark_rep_tf(cosine, bins = 30),
+  bin100 = tf:::spark_rep_tf(cosine, bins = 100)
 )
 
 
@@ -77,19 +89,9 @@ microbenchmark::microbenchmark(
 
 #------------------------------------------------------------------------------
 
-# !! not working (well) in print.tbl_df:
+# working in print.tbl_df as well
 
-# does work in principle:
 tibble::tibble(a = 1:10, b = tf_rgp(10, arg = 5))
+
 # but not for real data:
 tidyfun::chf_df[, 7:8]
-tidyfun::chf_df[, 8:7]
-
-# reason (probably): since the default width of the format.tf output is
-# options()$width, pillar:::ctl_colonnade always detects overflowing lines for
-# the table body and omits these columns (and all columns after them):
-options(width = 1500)
-tidyfun::chf_df[, 7:8]
-
-# !! need to figure out a way to use more aggressive binning when called from pillar --
-# this seems to not be calling tidyfun:::pillar_shaft.tf but format.tf for some reason ...

--- a/attic/dev-sparklines.R
+++ b/attic/dev-sparklines.R
@@ -1,8 +1,8 @@
 library("tf")
-options(width = 60)
+options(width = 80)
 
 t <- seq(0, 1, l = 301)
-sincos <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd()
+sincos <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd(arg = t)
 sincos
 
 tfb(sincos)
@@ -12,21 +12,29 @@ sincos |> tf_sparsify()
 sincos[1] <- NA
 sincos
 
-options(width = 40, digits = 2)
+options(width = 40)
 sincos
 
 tfb(tidyfun::dti_df$rcst[1:10])
+# if names are (too) long, rightmost edges get cut off :(
 tidyfun::chf_df$activity[1:10]
+
+
+# check: sparklines show values rel. to *global* min/max:
+min_max <- tfd(rep(1, 20)) / 2^seq(-3, 3, l = 10)
+print(min_max, n = 3)
+print(min_max, n = 10)
+print(rev(min_max), n = 3)
 
 # --------
 
-tf:::spark_rep_tf(sincos)
-tf:::spark_rep_tf(sincos, bins = 30)
+options(width = 60)
 
 act <- tidyfun::chf_df$activity[1:20]
-plot(act[1:5], type = "lasagna")
-tf:::spark_rep_tf(act[1:5])
-tf:::spark_rep_tf(act[1:5], bins = 50)
+tf:::spark_rep_tf(act[1:2], bins = 2000)
+tf:::spark_rep_tf(act[1:2], bins = 100)
+tf:::spark_rep_tf(act[1:2], bins = 50)
+tf:::spark_rep_tf(act[1:2], bins = 10)
 
 rcst_b <- tfb(
   tidyfun::dti_df$rcst[1:10],
@@ -35,15 +43,22 @@ rcst_b <- tfb(
   m = c(2, 1)
 )
 plot(rcst_b[1:3], col = 1:5)
-tf:::spark_rep_tf(rcst_b[1:3])
+tf:::spark_rep_tf(rcst_b[1:3], bins = 100)
 tf:::spark_rep_tf(rcst_b[1:3], bins = 30)
+
+# also looks good in glimpse / pillar:
+tibble::glimpse(tidyfun::chf_df)
+tidyfun:::pillar_shaft.tf(tidyfun::chf_df$activity)
+
+
+# ---------
 
 microbenchmark::microbenchmark(
   string = tf:::string_rep_tf(sincos),
   nobin = tf:::spark_rep_tf(sincos),
   bin30 = tf:::spark_rep_tf(sincos, bins = 30),
   bin100 = tf:::spark_rep_tf(sincos, bins = 100)
-) # x1, x15
+)
 
 
 microbenchmark::microbenchmark(
@@ -51,12 +66,30 @@ microbenchmark::microbenchmark(
   nobin = tf:::spark_rep_tf(act),
   bin30 = tf:::spark_rep_tf(act, bins = 30),
   bin100 = tf:::spark_rep_tf(act, bins = 100)
-) # x6, x6
-
+)
 
 microbenchmark::microbenchmark(
   string = tf:::string_rep_tf(rcst_b),
   nobin = tf:::spark_rep_tf(rcst_b),
   bin30 = tf:::spark_rep_tf(rcst_b, bins = 30),
   bin100 = tf:::spark_rep_tf(rcst_b, bins = 100)
-) # x10
+)
+
+#------------------------------------------------------------------------------
+
+# !! not working (well) in print.tbl_df:
+
+# does work in principle:
+tibble::tibble(a = 1:10, b = tf_rgp(10, arg = 5))
+# but not for real data:
+tidyfun::chf_df[, 7:8]
+tidyfun::chf_df[, 8:7]
+
+# reason (probably): since the default width of the format.tf output is
+# options()$width, pillar:::ctl_colonnade always detects overflowing lines for
+# the table body and omits these columns (and all columns after them):
+options(width = 1500)
+tidyfun::chf_df[, 7:8]
+
+# !! need to figure out a way to use more aggressive binning when called from pillar --
+# this seems to not be calling tidyfun:::pillar_shaft.tf but format.tf for some reason ...

--- a/man/tfdisplay.Rd
+++ b/man/tfdisplay.Rd
@@ -59,7 +59,7 @@
 \item{prefix}{prefix with names / index positions? defaults to \code{FALSE}}
 }
 \value{
-prints out \code{x} and returns it invisibly
+\strong{\code{print}}: prints out \code{x} and returns it invisibly
 
 a character representation of \code{x}
 }
@@ -69,7 +69,7 @@ give finer control.
 }
 \details{
 By default, \code{tf} objects on regular grids are shown as
-\href{cli::spark_bar}{sparklines}, set \code{sparkline = FALSE} for a text
+"sparklines" (\code{\link[cli:spark_bar]{cli::spark_bar()}}), set \code{sparkline = FALSE} for a text
 representation.
 
 Sparklines are based on running mean values of the function values, but
@@ -82,16 +82,16 @@ argument to set the number of bins explicitly.
 For \code{\link[tibble:reexports]{tibble::glimpse()}}, we use 8 bins by default for compact display.
 }
 \examples{
-t <- seq(0, 1, l = 101)
-cosine <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd(arg = t)
+t <- seq(0, 1, l = 201)
+cosine <- lapply(1:4, \(i) cos(i * pi * t)) |> tfd(arg = t)
 cosine
 tf_sparsify(cosine, dropout = .8)
 
 format(cosine, sparkline = FALSE)
 format(cosine, bins = 5)
 format(cosine, bins = 40)
-#! very non-equidistant grids --> sparklines can mislead
-cosine_2 <- tfd(cosine, arg = t^3)
-format(cosine_2, bins = 40)
+
+#! very non-equidistant grids --> sparklines can mislead about actual shapes:
+tfd(cosine, arg = t^3)
 }
 \concept{tidyfun print}

--- a/man/tfdisplay.Rd
+++ b/man/tfdisplay.Rd
@@ -21,17 +21,17 @@
   digits = 2,
   nsmall = 0,
   width = options()$width,
-  n = 5,
-  prefix = TRUE,
+  sparkline = TRUE,
+  prefix = FALSE,
   ...
 )
 }
 \arguments{
 \item{x}{any \R object (conceptually); typically numeric.}
 
-\item{n}{how many elements of \code{x} to print out}
+\item{n}{how many elements of \code{x} to print out at most}
 
-\item{...}{further arguments passed to or from other methods.}
+\item{...}{handed over to \code{\link[=format.tf]{format.tf()}}}
 
 \item{digits}{a positive integer indicating how many significant digits
     are to be used for
@@ -53,12 +53,45 @@
     objects.  \code{NULL} corresponds to the default \code{12}.
   }
 
-\item{prefix}{used internally.}
+\item{sparkline}{use a sparkline representation? defaults to \code{TRUE}
+(not available for irregular data)}
+
+\item{prefix}{prefix with names / index positions? defaults to \code{FALSE}}
 }
 \value{
 prints out \code{x} and returns it invisibly
+
+a character representation of \code{x}
 }
 \description{
-Print/format \code{tf}-objects.
+Prints and formats \code{tf}-objects for display. See Details / examples for options that
+give finer control.
+}
+\details{
+By default, \code{tf} objects on regular grids are shown as
+\href{cli::spark_bar}{sparklines}, set \code{sparkline = FALSE} for a text
+representation.
+
+Sparklines are based on running mean values of the function values, but
+these don't check for non-equidistant grids, so the visual impression will be
+misleading for very unequal grid distances.
+
+Sparklines use
+\code{options()$width/3} bins for printing/formatting by default, use \code{bins}
+argument to set the number of bins explicitly.
+For \code{\link[tibble:reexports]{tibble::glimpse()}}, we use 8 bins by default for compact display.
+}
+\examples{
+t <- seq(0, 1, l = 101)
+cosine <- purrr::map(1:5, \(i) cos(2 * pi * i * t)) |> tfd(arg = t)
+cosine
+tf_sparsify(cosine, dropout = .8)
+
+format(cosine, sparkline = FALSE)
+format(cosine, bins = 5)
+format(cosine, bins = 40)
+#! very non-equidistant grids --> sparklines can mislead
+cosine_2 <- tfd(cosine, arg = t^3)
+format(cosine_2, bins = 40)
 }
 \concept{tidyfun print}

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -16,7 +16,7 @@ lin_irreg <- {
   tfd(m, evaluator = tf_approx_linear)
 }
 
-lin_b <- tfb(lin, verbose = FALSE)
+lin_b <- tfb(lin, verbose = FALSE) |> suppressWarnings()
 
 test_that("MBD works", {
   ranks <- c(1.5, 3.5, 5.5, 7, 5.5, 3.5, 1.5)

--- a/tests/testthat/test-split-combine.R
+++ b/tests/testthat/test-split-combine.R
@@ -74,7 +74,7 @@ test_that("tf_combine works as expected", {
 
   tfs <- tf_split(x, splits = c(0.2, 0.6), include = "left")
   tfs2_sparse <- tf_sparsify(tfs[[2]])
-  tfs3_spline <- tfb(tfs[[3]], verbose = FALSE)
+  tfs3_spline <- tfb(tfs[[3]], verbose = FALSE) |> suppressWarnings()
   expect_class(tf_combine(tfs[[1]], tfs2_sparse, tfs3_spline), "tfd_irreg")
   expect_equal(
     tf_combine(tfs[[1]], tfs2_sparse, tfs3_spline) |> tf_domain(),

--- a/tests/testthat/test-tfb-spline.R
+++ b/tests/testthat/test-tfb-spline.R
@@ -70,22 +70,43 @@ test_that("tfb_spline works for fda::fdSmooth input", {
 })
 
 test_that("tfb_spline defaults work for all kinds of irregular input", {
-  expect_s3_class(tfb_spline(irr, verbose = FALSE), "tfb_spline")
-  expect_message(tfb_spline(irr), "100")
-  expect_length(tfb_spline(irr, verbose = FALSE), length(irr))
-  expect_message(tfb_spline(irr_df), "100")
-
-  irr_tfb_ <- tfb_spline(irr_list, arg = tf_arg(irr), verbose = FALSE)
-  expect_s3_class(irr_tfb_, "tfb_spline")
-  expect_length(irr_tfb_, length(irr))
+  expect_warning(
+    tfb_spline(irr, verbose = FALSE),
+    "Sparse data"
+  )
+  expect_s3_class(
+    tfb_spline(irr, verbose = FALSE) |> suppressWarnings(),
+    "tfb_spline"
+  )
+  irr_tfb_1 <- tfb_spline(irr, verbose = FALSE) |> suppressWarnings()
+  expect_length(irr_tfb_1, length(irr))
   expect_equal(
-    tf_evaluate(irr_tfb_, tf_arg(irr)),
+    tf_evaluations(irr_tfb_1),
+    tfb_spline(irr_df, verbose = FALSE) |>
+      tf_evaluations() |>
+      suppressWarnings()
+  )
+
+  expect_warning(
+    tfb_spline(irr_list, arg = tf_arg(irr), verbose = FALSE),
+    "Sparse data"
+  )
+  irr_tfb_2 <- tfb_spline(irr_list, arg = tf_arg(irr), verbose = FALSE) |>
+    suppressWarnings()
+  expect_s3_class(irr_tfb_2, "tfb_spline")
+  expect_length(irr_tfb_2, length(irr))
+  expect_equal(
+    tf_evaluate(irr_tfb_2, tf_arg(irr)),
     tf_evaluations(irr),
     tolerance = 1e-1
   )
 
   for (dat in list(irr_matrix, irr_df)) {
-    irr_tfb_ <- tfb_spline(dat, verbose = FALSE)
+    expect_warning(
+      tfb_spline(dat, verbose = FALSE),
+      "Sparse data"
+    )
+    irr_tfb_ <- tfb_spline(dat, verbose = FALSE) |> suppressWarnings()
     expect_s3_class(irr_tfb_, "tfb_spline")
     expect_length(irr_tfb_, length(irr))
     expect_equal(
@@ -100,7 +121,7 @@ test_that("tfb_spline defaults work for all kinds of irregular input", {
 test_that("unpenalized tfb_spline works", {
   expect_error(
     tfb_spline(narrow, k = 11, penalized = FALSE, verbose = FALSE),
-    "reduce k"
+    "too sparse"
   )
   expect_s3_class(
     tfb_spline(narrow, k = 8, penalized = FALSE, verbose = FALSE),


### PR DESCRIPTION
slightly chaotic PR because I came across some other issues with NA handling etc, but this seems to work well now:

``` r
t <- seq(0, 1, l = 101)
cosine <- purrr::map(1:5, \(i) cos(2 * pi * i * t) * i) |> tfd(arg = t)
cosine
#> tfd[5]: [0,1] -> [-5,5] based on 101 evaluations each
#> interpolation by tf_approx_linear 
#> [1]: ▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▅▅▅▅▅▅▅
#> [2]: ▆▆▅▄▄▃▃▃▄▄▅▆▆▆▆▅▄▄▃▃▃▄▄▅▆▆
#> [3]: ▇▆▄▃▂▃▄▆▇▆▅▃▂▂▃▅▆▇▆▄▃▂▃▄▆▇
#> [4]: ▇▅▂▂▄▆█▆▄▂▂▅▇▇▅▂▂▄▆█▆▄▂▂▅▇
#> [5]: █▄▁▃▇█▅▁▂▆█▅▁▁▅█▆▂▁▅█▇▃▁▄█

format(cosine, sparkline = FALSE)
#> [1] "(0.00,1.00);(0.01,1.00);(0.02,0.99); ..."
#> [2] "(0.00, 2.0);(0.01, 2.0);(0.02, 1.9); ..."
#> [3] "(0.00, 3.0);(0.01, 2.9);(0.02, 2.8); ..."
#> [4] "(0.00, 4.0);(0.01, 3.9);(0.02, 3.5); ..."
#> [5] "(0.00, 5.0);(0.01, 4.8);(0.02, 4.0); ..."
format(cosine, bins = 5)
#> [1] "▅▄▄▄▅" "▅▄▆▄▅" "▄▅▃▅▄" "▄▅▅▅▄" "▅▅▅▅▅"
format(cosine, bins = 40)
#> [1] "▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▅▅▅▅▅▅▅▅▅▅"
#> [2] "▆▆▆▅▅▄▄▃▃▃▃▃▃▄▄▅▅▆▆▆▆▆▆▅▅▄▄▃▃▃▃▃▃▄▄▅▅▆▆▆"
#> [3] "▇▆▆▄▃▂▂▂▃▄▅▆▇▇▇▆▅▃▃▂▂▃▃▅▆▇▇▇▆▅▄▃▂▂▂▃▄▆▆▇"
#> [4] "█▆▅▃▂▂▃▅▆██▆▅▃▂▂▃▅▆██▆▅▃▂▂▃▅▆██▆▅▃▂▂▃▅▆█"
#> [5] "█▆▃▁▁▃▆██▆▃▁▁▃▆██▆▃▁▁▃▆██▆▃▁▁▃▆██▆▃▁▁▃▆█"



tfb(cosine)
#> Percentage of input data variability preserved in basis representation
#> (per functional observation, approximate):
#> Min. 1st Qu.  Median Mean 3rd Qu.  Max.
#> 99.90 100.00 100.00 99.98 100.00 100.00
#> tfb[5]: [0,1] -> [-5.046792,5.302509] in basis representation:
#>  using  s(arg, bs = "cr", k = 25, sp = -1)  
#> 1: ▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▄▄▅▅▅▅▅▅
#> 2: ▆▅▅▄▃▃▃▃▄▄▅▆▆▆▅▅▄▃▃▃▃▄▄▅▆▆
#> 3: ▆▅▃▂▂▃▅▆▇▆▄▃▂▂▄▆▇▆▅▄▂▂▃▅▆▇
#> 4: ▇▄▂▂▅▇▇▅▂▁▃▆▇▇▄▂▂▅▇▇▅▂▁▃▆█
#> 5: ▇▂▁▄██▃▁▃██▃▁▂▇█▄▁▂▇█▆▁▁▆█
cosine |> tf_sparsify()
#> irregular tfd[5]: [0,1] -> [-5,5] based on 43 to 55 (mean: 48) evaluations each
#> interpolation by tf_approx_linear 
#> [1]: (0.00,1.00);(0.02,0.99);(0.03,0.98); ...
#> [2]: (0.00, 2.0);(0.03, 1.9);(0.04, 1.8); ...
#> [3]: (0.00, 3.0);(0.03, 2.5);(0.04, 2.2); ...
#> [4]: (0.00, 4.0);(0.01, 3.9);(0.03, 2.9); ...
#> [5]: (0.00, 5.0);(0.02, 4.0);(0.06,-1.5); ...


(rcst_b <- tfb(tidyfun::dti_df$rcst[1:10], verbose = FALSE))
#> tfb[10]: [0,1] -> [0.1279125,0.7539482] in basis representation:
#>  using  s(arg, bs = "cr", k = 25, sp = -1)  
#> 1001_1: ▄▄▄▅▅▆▆▆▇███████▇▆▆▄▃▄▅▅▅▅
#> 1002_1: ▁▂▃▃▄▅▅▆▇██████▇▆▆▅▃▄▅▅▅▅▅
#> 1003_1: ▅▅▅▅▄▄▄▅▅▆▇▆▆▆▆▆▇▇▆▄▃▄▆▅▅▅
#> 1004_1: ▅▅▅▅▄▄▅▆▇▇██▇██▇▇▆▄▃▄▅▅▅▅▅
#> 1005_1: ▂▂▃▃▃▄▅▅▅▆▆▆▆▇██▇▅▄▄▄▄▄▅▅▄
#>     [....]   (5 not shown)
(act <- tidyfun::chf_df$activity)
#> tfd[329]: [1,1440] -> [0,9.204926] based on 1440 evaluations each
#> interpolation by tf_approx_linear 
#> [1]: ▁▂▁▁▁▁▁▁▂▃▅▅▁▁▁▂▃▅▅▂▂▂▂▂▂▁
#> [2]: ▁▁▁▁▁▃▂▁▁▁▄▄▄▅▄▅▅▄▅▅▄▅▂▃▄▂
#> [3]: ▁▁▁▁▁▁▁▁▂▄▆▅▁▁▁▁▂▄▄▂▄▃▃▃▃▁
#> [4]: ▁▁▁▁▁▁▁▁▃▆▅▆▅▅▅▅▅▅▆▄▃▄▅▅▃▃
#> [5]: ▁▁▁▂▂▁▁▂▃▄▅▅▂▁▁▁▂▅▄▄▃▃▂▂▂▁
#>     [....]   (324 not shown)
```

``` r

# also looks good in glimpse / pillar / print_tbl:
tibble::glimpse(tidyfun::chf_df)
#> Rows: 329
#> Columns: 8
#> $ id         <dbl> 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4,…
#> $ gender     <chr> "Male", "Male", "Male", "Male", "Male", "Male", "Male", "Fe…
#> $ age        <dbl> 41, 41, 41, 41, 41, 41, 41, 81, 81, 81, 81, 81, 81, 81, 48,…
#> $ bmi        <dbl> 26, 26, 26, 26, 26, 26, 26, 21, 21, 21, 21, 21, 21, 21, 26,…
#> $ event_week <dbl> 41, 41, 41, 41, 41, 41, 41, 32, 32, 32, 32, 32, 32, 32, 46,…
#> $ event_type <chr> ".", ".", ".", ".", ".", ".", ".", ".", ".", ".", ".", ".",…
#> $ day        <ord> Mon, Tue, Wed, Thu, Fri, Sat, Sun, Mon, Tue, Wed, Thu, Fri,…
#> $ activity   <tfd_reg> ▁▁▂▄▁▅▂▂, ▁▂▁▄▅▅▄▃, ▁▁▂▄▁▄▃▃, ▁▁▃▆▆▅▄▄, ▁▂▃▄▁▄▃▂, ▁▁▂▅▅…
tidyfun:::pillar_shaft.tf(tidyfun::chf_df$activity[1:10])
#> <pillar_ornament>
#> ▁▁▃▂▃▂
#> ▁▂▃▅▅▃
#> ▁▁▄▁▄▃
#> ▁▁▅▅▄▄
#> ▁▁▄▁▄▂
#> ▁▁▄▅▃▅
#> ▄▃▅▆▅▅
#> ▅▄▄▅▄▅
#> ▁▂▂▅▆▄
#> ▂▂▃▅▅▄
tidyfun::chf_df[, 5:8]
#> # A tibble: 329 × 4
#>    event_week event_type day                     activity
#>         <dbl> <chr>      <ord>                  <tfd_reg>
#>  1         41 .          Mon   ▁▂▁▁▁▁▁▁▂▃▅▆▁▁▁▂▃▅▅▂▂▂▃▃▂▁
#>  2         41 .          Tue   ▁▁▁▁▁▃▂▁▂▁▄▄▄▆▅▆▅▄▆▅▅▅▂▃▄▂
#>  3         41 .          Wed   ▁▁▁▁▁▁▁▁▂▅▆▅▁▁▁▁▂▅▅▂▄▃▄▃▃▁
#>  4         41 .          Thu   ▁▁▁▁▁▁▁▁▃▆▅▆▅▆▆▆▅▆▆▄▄▄▅▅▃▃
#>  5         41 .          Fri   ▁▁▁▂▂▁▁▂▃▄▆▅▂▁▁▁▂▅▅▄▃▃▂▂▃▁
#>  6         41 .          Sat   ▁▁▁▁▁▁▁▂▃▃▅▆▅▅▅▆▄▄▅▅▂▂▅▅▅▅
#>  7         41 .          Sun   ▅▄▄▃▃▃▃▃▄▅▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅
#>  8         32 .          Mon   ▆▅▄▅▄▄▆▄▄▄▆▅▃▅▅▆▅▅▅▅▄▅▅▄▅▆
#>  9         32 .          Tue   ▂▁▂▁▁▁▁▄▂▁▁▂▆▆▅▅▄▅▆▇▇▆▅▄▄▅
#> 10         32 .          Wed   ▃▂▂▁▁▂▃▁▃▁▁▄▆▆▅▆▅▄▆▆▆▅▄▄▅▂
#> # ℹ 319 more rows
```

``` r

#! 2-25 times slower, still just microseconds so who cares:

microbenchmark::microbenchmark(
  string = tf:::string_rep_tf(cosine),
  nobin = tf:::spark_rep_tf(cosine),
  bin30 = tf:::spark_rep_tf(cosine, bins = 30),
  bin100 = tf:::spark_rep_tf(cosine, bins = 100)
)
#> Unit: microseconds
#>    expr      min        lq      mean   median        uq        max neval cld
#>  string  768.921  795.7765   836.866  827.593  851.8025   1231.936   100  a 
#>   nobin  984.219 1000.6565  1031.883 1013.503 1029.7880   1441.128   100  a 
#>   bin30 9081.443 9293.7830  9834.453 9452.078 9766.9420  14352.007   100   b
#>  bin100 9096.643 9308.9565 11383.071 9519.639 9781.9600 154404.388   100   b


microbenchmark::microbenchmark(
  string = tf:::string_rep_tf(act),
  nobin = tf:::spark_rep_tf(act),
  bin30 = tf:::spark_rep_tf(act, bins = 30),
  bin100 = tf:::spark_rep_tf(act, bins = 100)
)
#> Unit: milliseconds
#>    expr       min        lq      mean    median        uq       max neval cld
#>  string  13.49519  14.87625  16.32003  15.44557  16.38998  32.54929   100 a  
#>   nobin 134.51435 152.19358 170.08681 157.31485 168.78357 432.01466   100  b 
#>   bin30 280.36141 306.12855 402.07266 387.04792 453.71091 710.78068   100   c
#>  bin100 280.13510 307.98992 383.66559 331.76890 448.25919 698.66068   100   c

microbenchmark::microbenchmark(
  string = tf:::string_rep_tf(rcst_b),
  nobin = tf:::spark_rep_tf(rcst_b),
  bin30 = tf:::spark_rep_tf(rcst_b, bins = 30),
  bin100 = tf:::spark_rep_tf(rcst_b, bins = 100)
)
#> Unit: milliseconds
#>    expr       min        lq      mean    median        uq       max neval cld
#>  string  1.198250  1.372587  1.449369  1.414125  1.457800  2.271914   100 a  
#>   nobin  1.979257  2.292581  2.356409  2.330868  2.366204  3.629566   100  b 
#>   bin30 15.239393 16.734741 17.531227 16.909053 17.507062 23.532082   100   c
#>  bin100  1.985153  2.302966  2.410534  2.342515  2.385935  5.940675   100  b
```

drawback I made out:

``` r
#! very non-equidistant grids --> sparklines can mislead
cosine_2 <- tfd(cosine, arg = t^3)
format(cosine_2, bins = 40)
#> [1] "▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▅▅▅▅"
#> [2] "▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▄▄▄▃▃▃▃▄▄▅▆▆▆▅▄▃▃▄▅▆"
#> [3] "▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▅▄▄▃▃▂▂▃▄▅▆▇▇▅▄▂▃▅▆▆▄▂▃▆"
#> [4] "█████████▇▇▇▇▆▆▅▄▃▂▁▁▂▄▆▇▇▆▃▂▂▅▇▇▂▂▆▇▃▂▆"
#> [5] "███████████▇▇▆▅▃▂▁▁▁▂▅▇█▇▃▁▂▅█▆▁▃█▆▁▅▆▂▆"
format(cosine, bins = 40)
#> [1] "▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▅▅▅▅▅▅▅▅▅▅"
#> [2] "▆▆▆▅▅▄▄▃▃▃▃▃▃▄▄▅▅▆▆▆▆▆▆▅▅▄▄▃▃▃▃▃▃▄▄▅▅▆▆▆"
#> [3] "▇▆▆▄▃▂▂▂▃▄▅▆▇▇▇▆▅▃▃▂▂▃▃▅▆▇▇▇▆▅▄▃▂▂▂▃▄▆▆▇"
#> [4] "█▆▅▃▂▂▃▅▆██▆▅▃▂▂▃▅▆██▆▅▃▂▂▃▅▆██▆▅▃▂▂▃▅▆█"
#> [5] "█▆▃▁▁▃▆██▆▃▁▁▃▆██▆▃▁▁▃▆██▆▃▁▁▃▆██▆▃▁▁▃▆█"
```
-- do we care? if yes, could 
1) try to make the binning more intelligent in messy grids, not sure this is doable in a robust way in full generality
2) not use sparklines if grid is not equidistant (but *smallish* differences in grid spacing, relative to bin sizes, don't actually matter...)

thoughts?
