### PR TITLE
docs: streamline some docs

### DIFF
--- a/R/approx.R
+++ b/R/approx.R
@@ -42,11 +42,11 @@ zoo_wrapper <- function(f, ...) {
 #' @rdname tf_approx
 #' @seealso tfd
 #' @export
-#' @param x new `arg` values to approximate/interpolate/extrapolate the function for
-#' @param arg the `arg` values of the `evaluations`
-#' @param evaluations the function values at `arg`
+#' @param x new `arg` values to approximate/interpolate/extrapolate the function for.
+#' @param arg the `arg` values of the `evaluations`.
+#' @param evaluations the function values at `arg`.
 #' @returns a vector of values of the function defined by the given
-#' \eqn{(x_i, f(x_i))}=`(arg, evaluations)`-tuples at new argument values `x`.
+#'   \eqn{(x_i, f(x_i))}=`(arg, evaluations)`-tuples at new argument values `x`.
 #' @family tidyfun inter/extrapolation functions
 tf_approx_linear <- zoo_wrapper(na.approx, na.rm = FALSE)
 

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -2,7 +2,7 @@
 #'
 #' These functions access, subset, replace and evaluate `tf` objects.
 #' For more information on creating `tf` objects and converting them to/from
-#' `list`, `data.frame` or `matrix`, see [tfd()] and [tfb()]. See Details.\cr
+#' `list`, `data.frame` or `matrix`, see [tfd()] and [tfb()]. See details.\cr
 #'
 #' Note that these break certain (terrible) R conventions for vector-like objects:\cr
 #'
@@ -13,9 +13,9 @@
 #'
 #' All of the above will trigger errors.
 #'
-#' @param x an `tf`
+#' @param x an `tf`.
 #' @param i index of the observations (`integer`ish, `character` or `logical`,
-#'   usual R rules apply)
+#'   usual R rules apply).
 #' @param j The `arg` used to evaluate the functions. A (list of) `numeric`
 #'   vectors. *NOT* interpreted as a column number but as the argument value of
 #'   the respective functional datum.
@@ -120,11 +120,11 @@
 }
 
 #' @param value `tf` object for subassignment. This is typed more strictly
-#' than concatenation:  subassignment only happens if the common type of
-#' `value` and `x` is the same as the type of `x`,
-#' so subassignment never changes the type of `x` but may do a
-#' potentially lossy cast of `value` to the type of `x` (with a warning).
-#'@rdname tfbrackets
+#'   than concatenation:  subassignment only happens if the common type of
+#'   `value` and `x` is the same as the type of `x`,
+#'   so subassignment never changes the type of `x` but may do a
+#'   potentially lossy cast of `value` to the type of `x` (with a warning).
+#' @rdname tfbrackets
 #' @family tidyfun bracket-operator
 #' @export
 `[<-.tf` <- function(x, i, value) {

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -34,13 +34,13 @@ quad_trapez <- function(arg, evaluations) {
 #' limits of the functions' domain due to these boundary constraints. Basis
 #' `"bs"` does not have this problem for sufficiently high orders, but tends to
 #' yield slightly less stable fits.
-#' @param f a `tf`-object
+#' @param f a `tf`-object.
 #' @param order order of differentiation. Maximal value for `tfb_spline` is 2.
 #' @param arg grid to use for the finite differences.
-#'   Not the `arg` of the returned object for `tfd`-inputs, see Details.
+#'   Not the `arg` of the returned object for `tfd`-inputs, see details.
 #' @param ... not used
 #' @returns a `tf` (with slightly different `arg` or `basis` for the
-#'   derivatives, see Details)
+#'   derivatives, see details).
 #' @export
 #' @family tidyfun calculus functions
 tf_derive <- function(f, arg, order = 1, ...) UseMethod("tf_derive")
@@ -159,13 +159,13 @@ tf_derive.tfb_fpc <- function(f, arg, order = 1, ...) {
 #' \int^{t}_{lower}f(s)ds}, for \eqn{t \in}`[lower, upper]`, is returned.
 #' @inheritParams tf_derive
 #' @param arg (optional) grid to use for the quadrature.
-#' @param lower lower limits of the integration range. For `definite=TRUE`, this
+#' @param lower lower limits of the integration range. For `definite = TRUE`, this
 #'   can be a vector of the same length as `f`.
 #' @param upper upper limits of the integration range (but see `definite` arg /
-#'   Description). For `definite=TRUE`, this can be a vector of the same length
+#'   description). For `definite = TRUE`, this can be a vector of the same length
 #'   as `f`.
 #' @param definite should the definite integral  be returned (default) or the
-#'   antiderivative. See Description.
+#'   antiderivative. See description.
 #' @returns For `definite = TRUE`, the definite integrals of the functions in
 #'   `f`. For `definite = FALSE` and `tf`-inputs, a `tf` object containing their
 #'   anti-derivatives

--- a/R/convert.R
+++ b/R/convert.R
@@ -5,10 +5,10 @@
 #'
 #' @rdname converters
 #' @inheritParams base::as.data.frame
-#' @param optional not used
+#' @param optional not used.
 #' @param unnest if `TRUE`, the function will return a data.frame with the
 #'   evaluated functions.
-#' @param x a `tf` object
+#' @param x a `tf` object.
 #' @returns **for `as.data.frame.tf`:** if `unnest` is `FALSE` (default), a
 #'   one-column `data.frame` with a `tf`-column containing `x`. if `unnest` is
 #'   `TRUE`, a 3-column data frame with columns `id` for the (unique) names of

--- a/R/depth.R
+++ b/R/depth.R
@@ -12,10 +12,10 @@
 #' MBD is \eqn{-2(MEI - 0.5)^2 + .5}.
 #
 #'
-#' @param x `tf` (or a matrix of evaluations)
-#' @param depth currently available: "MBD", i.e. modified 2-band depth, and "MEI"
-#' @param arg grid of evaluation points
-#' @param na.rm TRUE remove missing observations?
+#' @param x `tf` (or a matrix of evaluations).
+#' @param depth currently available: `"MBD"`, i.e. modified 2-band depth, and `"MEI"`.
+#' @param arg grid of evaluation points.
+#' @param na.rm remove missing observations? Defaults to `TRUE`.
 #' @param ... further arguments handed to the function computing the respective
 #'   tf_depth.
 #' @returns vector of tf_depth values

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -9,7 +9,7 @@
 #' @param evaluator optional. The function to use for inter/extrapolating the
 #'  `tfd`. Defaults to `tf_evaluator(object)`.
 #'  See e.g. [tf_approx_linear()] for details.
-#' @param ... not used
+#' @param ... not used.
 #' @returns A list of numeric vectors containing the function
 #'   evaluations on `arg`.
 #' @export

--- a/R/fwise.R
+++ b/R/fwise.R
@@ -6,20 +6,20 @@
 #' of `NA`s for irregular `tfd` unless you set a [tf_evaluator()]-function
 #' that does inter- and extrapolation for them beforehand.
 #'
-#' @param x  a `tf` object
-#' @param y  a `tf` object
-#' @param arg defaults to standard argument values of `x`
-#' @param ... additional arguments for [purrr::as_mapper()]
+#' @param x  a `tf` object.
+#' @param y  a `tf` object.
+#' @param arg defaults to standard argument values of `x`.
+#' @param ... additional arguments for [purrr::as_mapper()].
 #' @name functionwise
 #' @family tidyfun summary functions
 #' @return a list (or vector) of the same length as `x` with the respective
-#'   summaries
+#'   summaries.
 NULL
 
 #' @export
 #' @describeIn functionwise User-specified function-wise summary statistics
 #' @param .f a function or formula that is applied to each entry of `x`, see
-#'   [purrr::as_mapper()] and Details.
+#'   [purrr::as_mapper()] and details.
 #' @details `tf_fwise` turns `x` into a list of data.frames with columns `arg`
 #' and `values` internally, so the function/formula in `.f` gets a data.frame
 #' `.x` with these columns, see examples below or source code for [tf_fmin()],

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -1,9 +1,9 @@
 #' Preprocess evaluation grid for plotting
 #'
 #' (internal function exported for re-use in upstream packages)
-#' @param f a `tf`-object
-#' @param n_grid length of evaluation grid
-#' @returns a semi-regular grid rounded down to appropriate resolution
+#' @param f a `tf`-object.
+#' @param n_grid length of evaluation grid.
+#' @returns a semi-regular grid rounded down to appropriate resolution.
 #' @export
 #' @family tidyfun developer tools
 prep_plotting_arg <- function(f, n_grid) {
@@ -31,18 +31,18 @@ prep_plotting_arg <- function(f, n_grid) {
 #' data for `tfd`-objects without inter-/extrapolation, use `n_grid < 1` or
 #' `n_grid = NA`.
 #'
-#' @param x an `tf` object
+#' @param x an `tf` object.
 #' @param y (optional) numeric vector to be used as `arg`
-#'   (i.e., for the **x**-axis...!)
+#'   (i.e., for the **x**-axis...!).
 #' @param n_grid minimal size of equidistant grid used for plotting,
-#'   defaults to 50. See details.
+#'   defaults to `50`. See details.
 #' @param points should the original evaluation points be marked by points?
-#'   Defaults to `TRUE` for irregular `tfd` and FALSE for all others
-#' @param type "spaghetti": line plots, "lasagna": heat maps.
+#'   Defaults to `TRUE` for irregular `tfd` and `FALSE` for all others.
+#' @param type `"spaghetti"`: line plots, `"lasagna"`: heat maps.
 #' @param alpha alpha-value (see[grDevices::rgb()]) for noodle transparency.
 #'   Defaults to 2/(no. of observations). Lower is more transparent.
 #' @param ... additional arguments for [matplot()] ("spaghetti") or
-#'   [image()] ("lasagna")
+#'   [image()] ("lasagna").
 #' @returns the plotted `tf`-object, invisibly.
 #' @importFrom graphics matplot image axis
 #' @importFrom grDevices heat.colors rgb
@@ -186,10 +186,10 @@ lines.tf <- function(
 #' @export
 #' @rdname tfviz
 #' @family tidyfun visualization
-#' @param arg evaluation grid (vector)
+#' @param arg evaluation grid (vector).
 #' @param interpolate should functions be evaluated (i.e., inter-/extrapolated)
 #'   for arg for which no original data is available? Only relevant for
-#'   tfd, defaults to FALSE
+#'   tfd, defaults to `FALSE`.
 points.tf <- function(
   x,
   arg,

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -17,12 +17,12 @@
 #' you'll be better off doing FPCA-based imputation or other model-based
 #' approaches in most cases.**
 #'
-#' @param object an object inheriting from `tf`
+#' @param object an object inheriting from `tf`.
 #' @param arg a vector of argument values on which to evaluate the functions in
-#'   `object`
+#'   `object`.
 #' @param ...  additional arguments handed over to `tfd` or `tfb`, for the
-#'   construction of the returned object
-#' @returns a `tfd` or `tfb` object on the new grid given by `arg`
+#'   construction of the returned object.
+#' @returns a `tfd` or `tfb` object on the new grid given by `arg`.
 #' @seealso [tf_rebase()], which is more general.
 #' @family tidyfun inter/extrapolation functions
 #' @export

--- a/R/methods.R
+++ b/R/methods.R
@@ -2,10 +2,11 @@
 #'
 #' A bunch of methods & utilities that do what they say: get or set the
 #' respective attributes of a `tf`-object.
-#' @param f an `tf` object
-#' @param x an `tf` object
+#'
+#' @param f an `tf` object.
+#' @param x an `tf` object.
 #' @returns either the respective attribute or, for setters (assignment functions),
-#'  the input object with modified properties.
+#'   the input object with modified properties.
 #' @rdname tfmethods
 #' @family tidyfun utility functions
 #' @export

--- a/R/ops.R
+++ b/R/ops.R
@@ -18,13 +18,13 @@
 #'
 #' See examples below, many more are in `tests/testthat/test-ops.R`.
 #'
-#' @param x a `tf` or `numeric` object
-#' @param y a `tf` or `numeric` object
-#' @param op An arithmetic operator as a string
-#' @param ... `tf`-objects (not used for `Math` group generic)
-#' @param e1 an `tf` or a numeric vector
-#' @param e2 an `tf` or a numeric vector
-#' @returns a `tf`- or `logical` vector with the computed result
+#' @param x a `tf` or `numeric` object.
+#' @param y a `tf` or `numeric` object.
+#' @param op An arithmetic operator as a string.
+#' @param ... `tf`-objects (not used for `Math` group generic).
+#' @param e1 an `tf` or a numeric vector.
+#' @param e2 an `tf` or a numeric vector.
+#' @returns a `tf`- or `logical` vector with the computed result.
 #' @seealso [tf_fwise()] for scalar summaries of each function in a `tf`-vector
 #' @name tfgroupgenerics
 #' @family tidyfun compute functions

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -85,7 +85,7 @@ spark_rep_tf <- function(
 
 #' Pretty printing and formatting for functional data
 #'
-#' Prints and formats `tf`-objects for display. See Details / examples for options that
+#' Prints and formats `tf`-objects for display. See details / examples for options that
 #' give finer control.
 #'
 #' By default, `tf` objects on regular grids are shown as
@@ -101,9 +101,9 @@ spark_rep_tf <- function(
 #' argument to set the number of bins explicitly.
 #' For [tibble::glimpse()], we use 8 bins by default for compact display.
 #' @rdname tfdisplay
-#' @param n how many elements of `x` to print out at most, defaults to 6
-#' @param ... handed over to [format.tf()]
-#' @returns **`print`**: prints out `x` and returns it invisibly
+#' @param n how many elements of `x` to print out at most, defaults to `6`.
+#' @param ... handed over to [format.tf()].
+#' @returns **`print`**: prints out `x` and returns it invisibly.
 #' @export
 #' @family tidyfun print
 #' @examples
@@ -212,10 +212,10 @@ print.tfb <- function(x, n = 5, ...) {
 
 #' @rdname tfdisplay
 #' @inheritParams base::format.default
-#' @param prefix prefix with names / index positions? defaults to `FALSE`
+#' @param prefix prefix with names / index positions? defaults to `FALSE`.
 #' @param sparkline use a sparkline representation? defaults to `TRUE`
-#'   (not available for irregular data)
-#' @returns a character representation of `x`
+#'   (not available for irregular data).
+#' @returns a character representation of `x`.
 #' @export
 format.tf <- function(
   x,

--- a/R/rebase.R
+++ b/R/rebase.R
@@ -10,10 +10,10 @@
 #' `tf_rebase.tfd.tfb_spline`, `tf_rebase.tfd.tfb_fpc`, `tf_rebase.tfb.tfd`,
 #' `tf_rebase.tfb.tfb` that dispatch on `object_from`.
 #'
-#' @param object a `tf` object whose representation should be changed
+#' @param object a `tf` object whose representation should be changed.
 #' @param basis_from  the `tf` object with the desired basis, `arg`, `evaluator`, etc.
-#' @param arg optional new `arg` values, defaults to those of `basis_from`
-#' @param ... forwarded to the `tfb` or `tfd` constructors
+#' @param arg optional new `arg` values, defaults to those of `basis_from`.
+#' @param ... forwarded to the `tfb` or `tfd` constructors.
 #' @returns a `tf`-vector containing the data of `object` in the same representation
 #'   as `basis_from` (potentially modified by the arguments given in `...`).
 #'

--- a/R/rng.R
+++ b/R/rng.R
@@ -16,15 +16,15 @@
 #' \eqn{t, t' \in [a, b]}:
 #' \eqn{Cov(x(t), x(t')) =  \frac{(b - \max(s,t))(\min(s, t) - a)}{\phi (b - a)} + \sigma^2 \delta_{t}(t')}
 #'
-#' @param n how many realizations to draw
+#' @param n how many realizations to draw.
 #' @param arg vector of evaluation points (`arg` of the return object). Defaults
 #'   to (0, 0.02, 0.04, ..., 1). If given as a single **integer** (don't forget
 #'   the **`L`**...), creates a  regular grid of that length over (0,1).
 #'   If given as a `n`-long list of vectors, irregular functional data are created.
-#' @param scale scale parameter (see Description). Defaults to the width of the
+#' @param scale scale parameter (see description). Defaults to the width of the
 #'   domain divided by 10.
 #' @param cov type of covariance function to use. Implemented defaults are
-#'   `"squareexp"`, `"wiener"`, `"matern"`, see Description. Can also be any
+#'   `"squareexp"`, `"wiener"`, `"matern"`, see description. Can also be any
 #'   vectorized function returning \eqn{Cov(x(t), x(t'))} *without nugget
 #'   effect* for pairs of inputs t and t'.
 #' @param nugget nugget effect for additional white noise / unstructured
@@ -35,7 +35,7 @@
 #'   "squareexp".
 #' @param domain of the generated functions. If not provided, the range of the
 #'   supplied `arg` values.
-#' @returns an `tfd`-vector of length `n`
+#' @returns an `tfd`-vector of length `n`.
 #' @importFrom mvtnorm rmvnorm
 #' @export
 #' @family tidyfun RNG functions
@@ -135,13 +135,13 @@ tf_rgp <- function(
 #' - **jiggle** it by randomly moving around its `arg`-values inside the intervals defined by its grid neighbors on the original argument grid.
 #' - **sparsify** it by removing (100*`dropout`)% of the function values
 #'
-#' @param f a `tfd` object
+#' @param f a `tfd` object.
 #' @param amount how far away from original grid points can the jiggled grid points
 #'   lie, at most (relative to original distance to neighboring grid points).
 #'   Defaults to at most 40% (0.4) of the original grid distances. Must be lower
-#'   than 0.5
-#' @param ... additional args for the returned `tfd` in `tf_jiggle`
-#' @returns an (irregular) `tfd` object
+#'   than 0.5.
+#' @param ... additional args for the returned `tfd` in `tf_jiggle`.
+#' @returns an (irregular) `tfd` object.
 #' @importFrom stats runif
 #' @export
 #' @rdname tf_jiggle

--- a/R/smooth.R
+++ b/R/smooth.R
@@ -17,11 +17,11 @@
 #'   - **`savgol`** uses a window size of `k` = $<$number of
 #'   grid points$>$/10 (i.e., the nearest odd integer to that).
 #'
-#' @param x a `tf` object containing functional data
-#' @param method one of "lowess" (see [stats::lowess()]), "rollmean",
-#'   "rollmedian" (see [zoo::rollmean()]) or "savgol" (see [pracma::savgol()])
-#' @param verbose give lots of diagnostic messages? Defaults to TRUE
-#' @param ... arguments for the respective `method`. See Details.
+#' @param x a `tf` object containing functional data.
+#' @param method one of `"lowess"` (see [stats::lowess()]), `"rollmean"`,
+#'   `"rollmedian"` (see [zoo::rollmean()]) or `"savgol"` (see [pracma::savgol()]).
+#' @param verbose give lots of diagnostic messages? Defaults to `TRUE`.
+#' @param ... arguments for the respective `method`. See details.
 #' @returns a smoothed version of the input. For some methods/options, the
 #'   smoothed functions may be shorter than the original ones (at both ends).
 #' @export

--- a/R/split-combine.R
+++ b/R/split-combine.R
@@ -3,13 +3,13 @@
 #' `tf_split` separates each function into a vector of functions defined on a sub-interval of
 #' its domain, either with overlap at the cut points or without.
 #'
-#' @param x a `tf` object
-#' @param splits numeric vector containing `arg`-values at which to split
+#' @param x a `tf` object.
+#' @param splits numeric vector containing `arg`-values at which to split.
 #' @param include which of the end points defined by `splits` to include in each
 #'  of the resulting split functions. Defaults to `"both"`, other options are "`left`" or
 #'   "`right`". See examples.
 #'
-#' @return for `tf_split`: a list of `tf` objects
+#' @return for `tf_split`: a list of `tf` objects.
 #' @export
 #' @rdname tf_splitcombine
 #'

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -53,10 +53,10 @@ summarize_tf <- function(..., op = NULL, eval = FALSE, verbose = TRUE) {
 #' (e.g. `tf_fmean` for means, `tf_fmax` for max. values) of each entry
 #' in a `tf`-vector.
 #'
-#' @param x a `tf` object
+#' @param x a `tf` object.
 #' @param ... optional additional arguments.
 #' @returns a `tf` object with the computed result.\cr
-#' **`summary.tf`** returns a `tf`-vector with the mean function, the functional
+#'   **`summary.tf`** returns a `tf`-vector with the mean function, the functional
 #'   median, the *pointwise* min and max of `x`, and the *pointwise* min and max
 #'   of the central half of the functions in `x`, as defined by MBD (see
 #'   [tf_depth()]).

--- a/R/tfb-class.R
+++ b/R/tfb-class.R
@@ -21,9 +21,9 @@
 #' @param basis either "`spline`" (see [tfb_spline()], the default) or "`fpc`"
 #'   (see [tfb_fpc()]).
 #'   (`wavelet` not implemented yet)
-#' @param ... further arguments for [tfb_spline()] or [tfb_fpc()]
+#' @param ... further arguments for [tfb_spline()] or [tfb_fpc()].
 #' @returns a `tfb`-object (or a `data.frame`/`matrix` for the conversion
-#'   functions, obviously.)
+#'   functions, obviously).
 #' @rdname tfb
 #' @family tfb-class
 #' @export

--- a/R/tfb-fpc-utils.R
+++ b/R/tfb-fpc-utils.R
@@ -22,9 +22,9 @@
 #' see last example for [tfb_fpc()]
 #'
 #' @param data numeric matrix of function evaluations
-#'   (each row is one curve, no NAs)
-#' @param arg numeric vector of argument values
-#' @param pve percentage of variance explained
+#'   (each row is one curve, no NAs).
+#' @param arg numeric vector of argument values.
+#' @param pve percentage of variance explained.
 #' @returns a list with entries
 #' - `mu` estimated mean function (numeric vector)
 #' - `efunctions` estimated FPCs (numeric matrix, columns represent FPCs)

--- a/R/tfb-fpc.R
+++ b/R/tfb-fpc.R
@@ -98,15 +98,15 @@ new_tfb_fpc <- function(
 #' @export
 #' @param method the function to use that computes eigenfunctions and scores.
 #'   Defaults to [fpc_wsvd()], which is quick and easy but returns completely
-#'   unsmoothed eigenfunctions unlikely to be suited for noisy data. See Details.
+#'   unsmoothed eigenfunctions unlikely to be suited for noisy data. See details.
 #' @param ... arguments to the `method` which computes the
-#'  (regularized/smoothed) FPCA - see e.g. [fpc_wsvd()].
-#'  Unless set by the user, uses proportion of variance explained
-#'  `pve = 0.995` to determine the truncation levels.
+#'   (regularized/smoothed) FPCA - see e.g. [fpc_wsvd()].
+#'   Unless set by the user, uses proportion of variance explained
+#'   `pve = 0.995` to determine the truncation levels.
 #' @inheritParams tfb
 #' @returns an object of class `tfb_fpc`, inheriting from `tfb`.
-#'    The basis used by `tfb_fpc` is a `tfd`-vector containing the estimated
-#'    mean and eigenfunctions.
+#'   The basis used by `tfb_fpc` is a `tfd`-vector containing the estimated
+#'   mean and eigenfunctions.
 #' @seealso [fpc_wsvd()] for FPCA options.
 #' @rdname tfb_fpc
 #' @export

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -240,13 +240,13 @@ new_tfb_spline <- function(
 #'   ordinary least squares / ML estimates for basis coefficients. `FALSE` is
 #'   much faster but will overfit for noisy data if `k` is (too) large.
 #' @param global Defaults to `FALSE`. If `TRUE` and `penalized = TRUE`, all
-#'   functions share the same smoothing parameter (see Details).
+#'   functions share the same smoothing parameter (see details).
 #' @param verbose `TRUE` (default) outputs statistics about the fit achieved by
 #'   the basis and other diagnostic messages.
 #' @param ...  arguments to the calls to [mgcv::s()] setting up the basis (and
 #'   to [mgcv::magic()] or [mgcv::gam.fit()] if `penalized = TRUE`). Uses `k =
 #'   25` cubic regression spline basis functions (`bs = "cr"`) by default, but
-#'   should be set appropriately by the user. See Details and examples in the
+#'   should be set appropriately by the user. See details and examples in the
 #'   vignettes.
 #' @inheritParams tfb
 #' @returns a `tfb`-object

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -136,12 +136,12 @@ new_tfd <- function(
 #'
 #' @param data a `matrix`, `data.frame` or `list` of suitable shape, or another
 #'   `tf`-object. when this argument is `NULL` (i.e. when calling `tfd()`) this
-#'   returns a prototype of class `tfd`
+#'   returns a prototype of class `tfd`.
 #' @param ... not used in `tfd`, except for `tfd.tf` -- specify `arg` and
 #'   `ìnterpolate = TRUE` to turn an irregular `tfd` into a regular one, see
 #'   examples.
 #' @returns an `tfd`-object (or a `data.frame`/`matrix` for the conversion
-#'   functions, obviously.)
+#'   functions, obviously).
 #' @family tfd-class
 #' @export
 tfd <- function(data, ...) UseMethod("tfd")

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,10 +162,10 @@ same_basis <- function(x, y) {
 #' `in_range` and its infix-equivalent `%inr%` return `TRUE` for all values in
 #'  the numeric vector `f` that are within the range of values in `r`.
 #'
-#' @param f a numeric vector
+#' @param f a numeric vector.
 #' @param r numeric vector used to specify a range, only the minimum and maximum
 #'   of `r` are used.
-#' @returns a `logical` vector of the same length as `f`
+#' @returns a `logical` vector of the same length as `f`.
 #' @family tidyfun utility functions
 #' @export
 in_range <- function(f, r) {
@@ -186,7 +186,7 @@ get_args <- function(args, f) {
 #' Turns any object into a list
 #'
 #' See above.
-#' @param x any input
+#' @param x any input.
 #' @returns `x` turned into a list.
 #' @export
 #' @family tidyfun developer tools
@@ -197,7 +197,7 @@ ensure_list <- function(x) {
 #' Make syntactically valid unique names
 #'
 #' See above.
-#' @param x any input
+#' @param x any input.
 #' @returns `x` turned into a list.
 #' @export
 #' @family tidyfun developer tools

--- a/R/vctrs-cast.R
+++ b/R/vctrs-cast.R
@@ -44,7 +44,7 @@ same_args <- function(x, to) {
 #' @name vctrs
 #' @family tidyfun vctrs
 #' @inheritParams vctrs::vec_cast
-#' @param y Vectors to cast.
+#' @param y vectors to cast.
 #' @returns for `vec_cast`: the casted `tf`-vector, for `vec_ptype2`: the common prototype
 #' @seealso [vctrs::vec_cast()], [vctrs::vec_ptype2()]
 NULL

--- a/R/where.R
+++ b/R/where.R
@@ -12,7 +12,7 @@
 #' of the usual `dplyr` tricks are available as well, see examples.\cr
 #' Any `cond`ition evaluates to `NA` on `NA`-entries in `f`.
 #'
-#' @param f a `tf` object
+#' @param f a `tf` object.
 #' @param cond a logical expression about `value` (and/or `arg`) that defines a
 #'   condition about the functions, see examples and details.
 #' @param return for each entry in `f`, `tf_where` either returns *all* `arg`

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -2,15 +2,15 @@
 #'
 #' These are used to redefine or restrict the `domain` of `tf` objects.
 #'
-#' @param f a `tf`-object
+#' @param f a `tf`-object.
 #' @param begin numeric vector of length 1 or `length(f)`.
-#'  Defaults to the lower limit of the domain of `f`.
+#'   Defaults to the lower limit of the domain of `f`.
 #' @param end numeric vector of length 1 or `length(f)`.
-#'  Defaults to the upper limit of the domain of `f`.
+#'   Defaults to the upper limit of the domain of `f`.
 #' @param ... not used
 #' @returns an object like `f` on a new domain (potentially).
-#' Note that regular functional data and functions in basis representation will
-#'   be turned into irregular `tfd`-objects iff `begin` or `end` are not scalar.
+#'   Note that regular functional data and functions in basis representation will
+#'   be turned into irregular `tfd`-objects if `begin` or `end` are not scalar.
 #' @family tidyfun utility functions
 #' @export
 #' @examples

--- a/man/converters.Rd
+++ b/man/converters.Rd
@@ -13,12 +13,12 @@
 \method{as.function}{tf}(x, ...)
 }
 \arguments{
-\item{x}{a \code{tf} object}
+\item{x}{a \code{tf} object.}
 
 \item{row.names}{\code{NULL} or a character vector giving the row
     names for the data frame.  Missing values are not allowed.}
 
-\item{optional}{not used}
+\item{optional}{not used.}
 
 \item{unnest}{if \code{TRUE}, the function will return a data.frame with the
 evaluated functions.}

--- a/man/ensure_list.Rd
+++ b/man/ensure_list.Rd
@@ -7,7 +7,7 @@
 ensure_list(x)
 }
 \arguments{
-\item{x}{any input}
+\item{x}{any input.}
 }
 \value{
 \code{x} turned into a list.

--- a/man/fpc_wsvd.Rd
+++ b/man/fpc_wsvd.Rd
@@ -14,11 +14,11 @@ fpc_wsvd(data, arg, pve = 0.995)
 }
 \arguments{
 \item{data}{numeric matrix of function evaluations
-(each row is one curve, no NAs)}
+(each row is one curve, no NAs).}
 
-\item{arg}{numeric vector of argument values}
+\item{arg}{numeric vector of argument values.}
 
-\item{pve}{percentage of variance explained}
+\item{pve}{percentage of variance explained.}
 }
 \value{
 a list with entries

--- a/man/functionwise.Rd
+++ b/man/functionwise.Rd
@@ -35,14 +35,14 @@ tf_crosscov(x, y, arg = tf_arg(x))
 tf_crosscor(x, y, arg = tf_arg(x))
 }
 \arguments{
-\item{x}{a \code{tf} object}
+\item{x}{a \code{tf} object.}
 
 \item{.f}{a function or formula that is applied to each entry of \code{x}, see
-\code{\link[purrr:as_mapper]{purrr::as_mapper()}} and Details.}
+\code{\link[purrr:as_mapper]{purrr::as_mapper()}} and details.}
 
-\item{arg}{defaults to standard argument values of \code{x}}
+\item{arg}{defaults to standard argument values of \code{x}.}
 
-\item{...}{additional arguments for \code{\link[purrr:as_mapper]{purrr::as_mapper()}}}
+\item{...}{additional arguments for \code{\link[purrr:as_mapper]{purrr::as_mapper()}}.}
 
 \item{na.rm}{a logical (\code{TRUE} or \code{FALSE}) indicating
     whether missing values should be removed.}
@@ -50,11 +50,11 @@ tf_crosscor(x, y, arg = tf_arg(x))
 \item{finite}{logical, indicating if all non-finite elements should
     be omitted.}
 
-\item{y}{a \code{tf} object}
+\item{y}{a \code{tf} object.}
 }
 \value{
 a list (or vector) of the same length as \code{x} with the respective
-summaries
+summaries.
 }
 \description{
 These functions extract (user-specified) \strong{function-wise} summary statistics

--- a/man/in_range.Rd
+++ b/man/in_range.Rd
@@ -10,13 +10,13 @@ in_range(f, r)
 f \%inr\% r
 }
 \arguments{
-\item{f}{a numeric vector}
+\item{f}{a numeric vector.}
 
 \item{r}{numeric vector used to specify a range, only the minimum and maximum
 of \code{r} are used.}
 }
 \value{
-a \code{logical} vector of the same length as \code{f}
+a \code{logical} vector of the same length as \code{f}.
 }
 \description{
 \code{in_range} and its infix-equivalent \verb{\%inr\%} return \code{TRUE} for all values in

--- a/man/prep_plotting_arg.Rd
+++ b/man/prep_plotting_arg.Rd
@@ -7,12 +7,12 @@
 prep_plotting_arg(f, n_grid)
 }
 \arguments{
-\item{f}{a \code{tf}-object}
+\item{f}{a \code{tf}-object.}
 
-\item{n_grid}{length of evaluation grid}
+\item{n_grid}{length of evaluation grid.}
 }
 \value{
-a semi-regular grid rounded down to appropriate resolution
+a semi-regular grid rounded down to appropriate resolution.
 }
 \description{
 (internal function exported for re-use in upstream packages)

--- a/man/tf_approx.Rd
+++ b/man/tf_approx.Rd
@@ -22,11 +22,11 @@ tf_approx_locf(x, arg, evaluations)
 tf_approx_nocb(x, arg, evaluations)
 }
 \arguments{
-\item{x}{new \code{arg} values to approximate/interpolate/extrapolate the function for}
+\item{x}{new \code{arg} values to approximate/interpolate/extrapolate the function for.}
 
-\item{arg}{the \code{arg} values of the \code{evaluations}}
+\item{arg}{the \code{arg} values of the \code{evaluations}.}
 
-\item{evaluations}{the function values at \code{arg}}
+\item{evaluations}{the function values at \code{arg}.}
 }
 \value{
 a vector of values of the function defined by the given

--- a/man/tf_depth.Rd
+++ b/man/tf_depth.Rd
@@ -13,13 +13,13 @@ tf_depth(x, arg, depth = "MBD", na.rm = TRUE, ...)
 \method{tf_depth}{tf}(x, arg, depth = "MBD", na.rm = TRUE, ...)
 }
 \arguments{
-\item{x}{\code{tf} (or a matrix of evaluations)}
+\item{x}{\code{tf} (or a matrix of evaluations).}
 
-\item{arg}{grid of evaluation points}
+\item{arg}{grid of evaluation points.}
 
-\item{depth}{currently available: "MBD", i.e. modified 2-band depth, and "MEI"}
+\item{depth}{currently available: \code{"MBD"}, i.e. modified 2-band depth, and \code{"MEI"}.}
 
-\item{na.rm}{TRUE remove missing observations?}
+\item{na.rm}{remove missing observations? Defaults to \code{TRUE}.}
 
 \item{...}{further arguments handed to the function computing the respective
 tf_depth.}

--- a/man/tf_derive.Rd
+++ b/man/tf_derive.Rd
@@ -19,10 +19,10 @@ tf_derive(f, arg, order = 1, ...)
 \method{tf_derive}{tfb_fpc}(f, arg, order = 1, ...)
 }
 \arguments{
-\item{f}{a \code{tf}-object}
+\item{f}{a \code{tf}-object.}
 
 \item{arg}{grid to use for the finite differences.
-Not the \code{arg} of the returned object for \code{tfd}-inputs, see Details.}
+Not the \code{arg} of the returned object for \code{tfd}-inputs, see details.}
 
 \item{order}{order of differentiation. Maximal value for \code{tfb_spline} is 2.}
 
@@ -30,7 +30,7 @@ Not the \code{arg} of the returned object for \code{tfd}-inputs, see Details.}
 }
 \value{
 a \code{tf} (with slightly different \code{arg} or \code{basis} for the
-derivatives, see Details)
+derivatives, see details).
 }
 \description{
 Derivatives of \code{tf}-objects use finite differences of the evaluations for

--- a/man/tf_evaluate.Rd
+++ b/man/tf_evaluate.Rd
@@ -21,7 +21,7 @@ tf_evaluate(object, arg, ...)
 \item{arg}{optional evaluation grid (vector or list of vectors).
 Defaults to \code{tf_arg(object)}, implicitly.}
 
-\item{...}{not used}
+\item{...}{not used.}
 
 \item{evaluator}{optional. The function to use for inter/extrapolating the
 \code{tfd}. Defaults to \code{tf_evaluator(object)}.

--- a/man/tf_integrate.Rd
+++ b/man/tf_integrate.Rd
@@ -30,21 +30,21 @@ tf_integrate(f, arg, lower, upper, ...)
 )
 }
 \arguments{
-\item{f}{a \code{tf}-object}
+\item{f}{a \code{tf}-object.}
 
 \item{arg}{(optional) grid to use for the quadrature.}
 
-\item{lower}{lower limits of the integration range. For \code{definite=TRUE}, this
+\item{lower}{lower limits of the integration range. For \code{definite = TRUE}, this
 can be a vector of the same length as \code{f}.}
 
 \item{upper}{upper limits of the integration range (but see \code{definite} arg /
-Description). For \code{definite=TRUE}, this can be a vector of the same length
+description). For \code{definite = TRUE}, this can be a vector of the same length
 as \code{f}.}
 
 \item{...}{not used}
 
 \item{definite}{should the definite integral  be returned (default) or the
-antiderivative. See Description.}
+antiderivative. See description.}
 }
 \value{
 For \code{definite = TRUE}, the definite integrals of the functions in

--- a/man/tf_interpolate.Rd
+++ b/man/tf_interpolate.Rd
@@ -13,16 +13,16 @@ tf_interpolate(object, arg, ...)
 \method{tf_interpolate}{tfd}(object, arg, ...)
 }
 \arguments{
-\item{object}{an object inheriting from \code{tf}}
+\item{object}{an object inheriting from \code{tf}.}
 
 \item{arg}{a vector of argument values on which to evaluate the functions in
-\code{object}}
+\code{object}.}
 
 \item{...}{additional arguments handed over to \code{tfd} or \code{tfb}, for the
-construction of the returned object}
+construction of the returned object.}
 }
 \value{
-a \code{tfd} or \code{tfb} object on the new grid given by \code{arg}
+a \code{tfd} or \code{tfb} object on the new grid given by \code{arg}.
 }
 \description{
 Change the internal representation of a \code{tf}-object so that it

--- a/man/tf_jiggle.Rd
+++ b/man/tf_jiggle.Rd
@@ -10,19 +10,19 @@ tf_jiggle(f, amount = 0.4, ...)
 tf_sparsify(f, dropout = 0.5)
 }
 \arguments{
-\item{f}{a \code{tfd} object}
+\item{f}{a \code{tfd} object.}
 
 \item{amount}{how far away from original grid points can the jiggled grid points
 lie, at most (relative to original distance to neighboring grid points).
 Defaults to at most 40\% (0.4) of the original grid distances. Must be lower
-than 0.5}
+than 0.5.}
 
-\item{...}{additional args for the returned \code{tfd} in \code{tf_jiggle}}
+\item{...}{additional args for the returned \code{tfd} in \code{tf_jiggle}.}
 
 \item{dropout}{what proportion of values of \code{f} to drop, on average. Defaults to half.}
 }
 \value{
-an (irregular) \code{tfd} object
+an (irregular) \code{tfd} object.
 }
 \description{
 Randomly create some irregular functional data from regular ones.

--- a/man/tf_rebase.Rd
+++ b/man/tf_rebase.Rd
@@ -13,13 +13,13 @@ tf_rebase(object, basis_from, arg = tf_arg(basis_from), ...)
 \method{tf_rebase}{tfb}(object, basis_from, arg = tf_arg(basis_from), ...)
 }
 \arguments{
-\item{object}{a \code{tf} object whose representation should be changed}
+\item{object}{a \code{tf} object whose representation should be changed.}
 
 \item{basis_from}{the \code{tf} object with the desired basis, \code{arg}, \code{evaluator}, etc.}
 
-\item{arg}{optional new \code{arg} values, defaults to those of \code{basis_from}}
+\item{arg}{optional new \code{arg} values, defaults to those of \code{basis_from}.}
 
-\item{...}{forwarded to the \code{tfb} or \code{tfd} constructors}
+\item{...}{forwarded to the \code{tfb} or \code{tfd} constructors.}
 }
 \value{
 a \code{tf}-vector containing the data of \code{object} in the same representation

--- a/man/tf_rgp.Rd
+++ b/man/tf_rgp.Rd
@@ -15,7 +15,7 @@ tf_rgp(
 )
 }
 \arguments{
-\item{n}{how many realizations to draw}
+\item{n}{how many realizations to draw.}
 
 \item{arg}{vector of evaluation points (\code{arg} of the return object). Defaults
 to (0, 0.02, 0.04, ..., 1). If given as a single \strong{integer} (don't forget
@@ -23,11 +23,11 @@ the \strong{\code{L}}...), creates a  regular grid of that length over (0,1).
 If given as a \code{n}-long list of vectors, irregular functional data are created.}
 
 \item{cov}{type of covariance function to use. Implemented defaults are
-\code{"squareexp"}, \code{"wiener"}, \code{"matern"}, see Description. Can also be any
+\code{"squareexp"}, \code{"wiener"}, \code{"matern"}, see description. Can also be any
 vectorized function returning \eqn{Cov(x(t), x(t'))} \emph{without nugget
 effect} for pairs of inputs t and t'.}
 
-\item{scale}{scale parameter (see Description). Defaults to the width of the
+\item{scale}{scale parameter (see description). Defaults to the width of the
 domain divided by 10.}
 
 \item{nugget}{nugget effect for additional white noise / unstructured
@@ -42,7 +42,7 @@ function becomes numerically unstable for large (>20) \code{order}, use
 supplied \code{arg} values.}
 }
 \value{
-an \code{tfd}-vector of length \code{n}
+an \code{tfd}-vector of length \code{n}.
 }
 \description{
 Generates \code{n} realizations of a zero-mean Gaussian process. The function also

--- a/man/tf_smooth.Rd
+++ b/man/tf_smooth.Rd
@@ -18,14 +18,14 @@ tf_smooth(x, ...)
 )
 }
 \arguments{
-\item{x}{a \code{tf} object containing functional data}
+\item{x}{a \code{tf} object containing functional data.}
 
-\item{...}{arguments for the respective \code{method}. See Details.}
+\item{...}{arguments for the respective \code{method}. See details.}
 
-\item{verbose}{give lots of diagnostic messages? Defaults to TRUE}
+\item{verbose}{give lots of diagnostic messages? Defaults to \code{TRUE}.}
 
-\item{method}{one of "lowess" (see \code{\link[stats:lowess]{stats::lowess()}}), "rollmean",
-"rollmedian" (see \code{\link[zoo:rollmean]{zoo::rollmean()}}) or "savgol" (see \code{\link[pracma:savgol]{pracma::savgol()}})}
+\item{method}{one of \code{"lowess"} (see \code{\link[stats:lowess]{stats::lowess()}}), \code{"rollmean"},
+\code{"rollmedian"} (see \code{\link[zoo:rollmean]{zoo::rollmean()}}) or \code{"savgol"} (see \code{\link[pracma:savgol]{pracma::savgol()}}).}
 }
 \value{
 a smoothed version of the input. For some methods/options, the

--- a/man/tf_splitcombine.Rd
+++ b/man/tf_splitcombine.Rd
@@ -11,9 +11,9 @@ tf_split(x, splits, include = c("both", "left", "right"))
 tf_combine(..., strict = FALSE)
 }
 \arguments{
-\item{x}{a \code{tf} object}
+\item{x}{a \code{tf} object.}
 
-\item{splits}{numeric vector containing \code{arg}-values at which to split}
+\item{splits}{numeric vector containing \code{arg}-values at which to split.}
 
 \item{include}{which of the end points defined by \code{splits} to include in each
 of the resulting split functions. Defaults to \code{"both"}, other options are "\code{left}" or
@@ -27,7 +27,7 @@ defaults to \code{FALSE}. If \code{strict == FALSE}, only the first function val
 are used, the rest are discarded (with a warning).}
 }
 \value{
-for \code{tf_split}: a list of \code{tf} objects
+for \code{tf_split}: a list of \code{tf} objects.
 
 for \code{tf_combine}: a \code{tfd} with the combined subfunctions on the union of the input \code{tf_arg}-values
 }

--- a/man/tf_where.Rd
+++ b/man/tf_where.Rd
@@ -10,7 +10,7 @@ tf_where(f, cond, return = c("all", "first", "last", "range", "any"), arg)
 tf_anywhere(f, cond, arg)
 }
 \arguments{
-\item{f}{a \code{tf} object}
+\item{f}{a \code{tf} object.}
 
 \item{cond}{a logical expression about \code{value} (and/or \code{arg}) that defines a
 condition about the functions, see examples and details.}

--- a/man/tf_zoom.Rd
+++ b/man/tf_zoom.Rd
@@ -16,7 +16,7 @@ tf_zoom(f, begin, end, ...)
 \method{tf_zoom}{tfb_fpc}(f, begin = tf_domain(f)[1], end = tf_domain(f)[2], ...)
 }
 \arguments{
-\item{f}{a \code{tf}-object}
+\item{f}{a \code{tf}-object.}
 
 \item{begin}{numeric vector of length 1 or \code{length(f)}.
 Defaults to the lower limit of the domain of \code{f}.}
@@ -29,7 +29,7 @@ Defaults to the upper limit of the domain of \code{f}.}
 \value{
 an object like \code{f} on a new domain (potentially).
 Note that regular functional data and functions in basis representation will
-be turned into irregular \code{tfd}-objects iff \code{begin} or \code{end} are not scalar.
+be turned into irregular \code{tfd}-objects if \code{begin} or \code{end} are not scalar.
 }
 \description{
 These are used to redefine or restrict the \code{domain} of \code{tf} objects.

--- a/man/tfb.Rd
+++ b/man/tfb.Rd
@@ -20,11 +20,11 @@ as.tfb(data, basis = c("spline", "fpc"), ...)
 (see \code{\link[=tfb_fpc]{tfb_fpc()}}).
 (\code{wavelet} not implemented yet)}
 
-\item{...}{further arguments for \code{\link[=tfb_spline]{tfb_spline()}} or \code{\link[=tfb_fpc]{tfb_fpc()}}}
+\item{...}{further arguments for \code{\link[=tfb_spline]{tfb_spline()}} or \code{\link[=tfb_fpc]{tfb_fpc()}}.}
 }
 \value{
 a \code{tfb}-object (or a \code{data.frame}/\code{matrix} for the conversion
-functions, obviously.)
+functions, obviously).
 }
 \description{
 Various constructors for \code{tfb}-vectors from different kinds of inputs.

--- a/man/tfb_fpc.Rd
+++ b/man/tfb_fpc.Rd
@@ -57,7 +57,7 @@ evaluations.}
 
 \item{method}{the function to use that computes eigenfunctions and scores.
 Defaults to \code{\link[=fpc_wsvd]{fpc_wsvd()}}, which is quick and easy but returns completely
-unsmoothed eigenfunctions unlikely to be suited for noisy data. See Details.}
+unsmoothed eigenfunctions unlikely to be suited for noisy data. See details.}
 }
 \value{
 an object of class \code{tfb_fpc}, inheriting from \code{tfb}.

--- a/man/tfb_spline.Rd
+++ b/man/tfb_spline.Rd
@@ -113,7 +113,7 @@ tfb_spline(data, ...)
 
 \item{...}{arguments to the calls to \code{\link[mgcv:s]{mgcv::s()}} setting up the basis (and
 to \code{\link[mgcv:magic]{mgcv::magic()}} or \code{\link[mgcv:gam.fit]{mgcv::gam.fit()}} if \code{penalized = TRUE}). Uses \code{k = 25} cubic regression spline basis functions (\code{bs = "cr"}) by default, but
-should be set appropriately by the user. See Details and examples in the
+should be set appropriately by the user. See details and examples in the
 vignettes.}
 
 \item{id}{The name or number of the column defining which data belong to
@@ -139,7 +139,7 @@ ordinary least squares / ML estimates for basis coefficients. \code{FALSE} is
 much faster but will overfit for noisy data if \code{k} is (too) large.}
 
 \item{global}{Defaults to \code{FALSE}. If \code{TRUE} and \code{penalized = TRUE}, all
-functions share the same smoothing parameter (see Details).}
+functions share the same smoothing parameter (see details).}
 
 \item{verbose}{\code{TRUE} (default) outputs statistics about the fit achieved by
 the basis and other diagnostic messages.}

--- a/man/tfbrackets.Rd
+++ b/man/tfbrackets.Rd
@@ -11,10 +11,10 @@
 \method{[}{tf}(x, i) <- value
 }
 \arguments{
-\item{x}{an \code{tf}}
+\item{x}{an \code{tf}.}
 
 \item{i}{index of the observations (\code{integer}ish, \code{character} or \code{logical},
-usual R rules apply)}
+usual R rules apply).}
 
 \item{j}{The \code{arg} used to evaluate the functions. A (list of) \code{numeric}
 vectors. \emph{NOT} interpreted as a column number but as the argument value of
@@ -48,7 +48,7 @@ represents one \code{argval} as given in argument \code{j}, with an attribute
 \description{
 These functions access, subset, replace and evaluate \code{tf} objects.
 For more information on creating \code{tf} objects and converting them to/from
-\code{list}, \code{data.frame} or \code{matrix}, see \code{\link[=tfd]{tfd()}} and \code{\link[=tfb]{tfb()}}. See Details.\cr
+\code{list}, \code{data.frame} or \code{matrix}, see \code{\link[=tfd]{tfd()}} and \code{\link[=tfb]{tfb()}}. See details.\cr
 }
 \details{
 Note that these break certain (terrible) R conventions for vector-like objects:\cr

--- a/man/tfd.Rd
+++ b/man/tfd.Rd
@@ -41,7 +41,7 @@ as.tfd_irreg(data, ...)
 \arguments{
 \item{data}{a \code{matrix}, \code{data.frame} or \code{list} of suitable shape, or another
 \code{tf}-object. when this argument is \code{NULL} (i.e. when calling \code{tfd()}) this
-returns a prototype of class \code{tfd}}
+returns a prototype of class \code{tfd}.}
 
 \item{...}{not used in \code{tfd}, except for \code{tfd.tf} -- specify \code{arg} and
 \code{ìnterpolate = TRUE} to turn an irregular \code{tfd} into a regular one, see
@@ -69,7 +69,7 @@ evaluations.}
 }
 \value{
 an \code{tfd}-object (or a \code{data.frame}/\code{matrix} for the conversion
-functions, obviously.)
+functions, obviously).
 }
 \description{
 Various constructor methods for \code{tfd}-objects.

--- a/man/tfdisplay.Rd
+++ b/man/tfdisplay.Rd
@@ -29,9 +29,9 @@
 \arguments{
 \item{x}{any \R object (conceptually); typically numeric.}
 
-\item{n}{how many elements of \code{x} to print out at most, defaults to 6}
+\item{n}{how many elements of \code{x} to print out at most, defaults to \code{6}.}
 
-\item{...}{handed over to \code{\link[=format.tf]{format.tf()}}}
+\item{...}{handed over to \code{\link[=format.tf]{format.tf()}}.}
 
 \item{digits}{a positive integer indicating how many significant digits
     are to be used for
@@ -54,17 +54,17 @@
   }
 
 \item{sparkline}{use a sparkline representation? defaults to \code{TRUE}
-(not available for irregular data)}
+(not available for irregular data).}
 
-\item{prefix}{prefix with names / index positions? defaults to \code{FALSE}}
+\item{prefix}{prefix with names / index positions? defaults to \code{FALSE}.}
 }
 \value{
-\strong{\code{print}}: prints out \code{x} and returns it invisibly
+\strong{\code{print}}: prints out \code{x} and returns it invisibly.
 
-a character representation of \code{x}
+a character representation of \code{x}.
 }
 \description{
-Prints and formats \code{tf}-objects for display. See Details / examples for options that
+Prints and formats \code{tf}-objects for display. See details / examples for options that
 give finer control.
 }
 \details{

--- a/man/tfgroupgenerics.Rd
+++ b/man/tfgroupgenerics.Rd
@@ -56,20 +56,20 @@
 \method{cumprod}{tfb}(...)
 }
 \arguments{
-\item{e1}{an \code{tf} or a numeric vector}
+\item{e1}{an \code{tf} or a numeric vector.}
 
-\item{e2}{an \code{tf} or a numeric vector}
+\item{e2}{an \code{tf} or a numeric vector.}
 
-\item{op}{An arithmetic operator as a string}
+\item{op}{An arithmetic operator as a string.}
 
-\item{x}{a \code{tf} or \code{numeric} object}
+\item{x}{a \code{tf} or \code{numeric} object.}
 
-\item{y}{a \code{tf} or \code{numeric} object}
+\item{y}{a \code{tf} or \code{numeric} object.}
 
-\item{...}{\code{tf}-objects (not used for \code{Math} group generic)}
+\item{...}{\code{tf}-objects (not used for \code{Math} group generic).}
 }
 \value{
-a \code{tf}- or \code{logical} vector with the computed result
+a \code{tf}- or \code{logical} vector with the computed result.
 }
 \description{
 These methods and operators mostly work \code{arg}-value-wise on \code{tf} objects, see

--- a/man/tfmethods.Rd
+++ b/man/tfmethods.Rd
@@ -79,9 +79,9 @@ is_tfb_spline(x)
 is_tfb_fpc(x)
 }
 \arguments{
-\item{f}{an \code{tf} object}
+\item{f}{an \code{tf} object.}
 
-\item{x}{an \code{tf} object}
+\item{x}{an \code{tf} object.}
 
 \item{value}{\strong{for \verb{tf_evaluator<-}:} (bare or quoted) name of a function
 that can be used to interpolate an \code{tfd}. Needs to accept vector arguments

--- a/man/tfsummaries.Rd
+++ b/man/tfsummaries.Rd
@@ -32,7 +32,7 @@ var(x, y = NULL, na.rm = FALSE, use)
 \method{summary}{tf}(object, ...)
 }
 \arguments{
-\item{x}{a \code{tf} object}
+\item{x}{a \code{tf} object.}
 
 \item{...}{optional additional arguments.}
 

--- a/man/tfviz.Rd
+++ b/man/tfviz.Rd
@@ -28,30 +28,30 @@
 )
 }
 \arguments{
-\item{x}{an \code{tf} object}
+\item{x}{an \code{tf} object.}
 
 \item{y}{(optional) numeric vector to be used as \code{arg}
-(i.e., for the \strong{x}-axis...!)}
+(i.e., for the \strong{x}-axis...!).}
 
 \item{n_grid}{minimal size of equidistant grid used for plotting,
-defaults to 50. See details.}
+defaults to \code{50}. See details.}
 
 \item{points}{should the original evaluation points be marked by points?
-Defaults to \code{TRUE} for irregular \code{tfd} and FALSE for all others}
+Defaults to \code{TRUE} for irregular \code{tfd} and \code{FALSE} for all others.}
 
-\item{type}{"spaghetti": line plots, "lasagna": heat maps.}
+\item{type}{\code{"spaghetti"}: line plots, \code{"lasagna"}: heat maps.}
 
 \item{alpha}{alpha-value (see\code{\link[grDevices:rgb]{grDevices::rgb()}}) for noodle transparency.
 Defaults to 2/(no. of observations). Lower is more transparent.}
 
 \item{...}{additional arguments for \code{\link[=matplot]{matplot()}} ("spaghetti") or
-\code{\link[=image]{image()}} ("lasagna")}
+\code{\link[=image]{image()}} ("lasagna").}
 
-\item{arg}{evaluation grid (vector)}
+\item{arg}{evaluation grid (vector).}
 
 \item{interpolate}{should functions be evaluated (i.e., inter-/extrapolated)
 for arg for which no original data is available? Only relevant for
-tfd, defaults to FALSE}
+tfd, defaults to \code{FALSE}.}
 }
 \value{
 the plotted \code{tf}-object, invisibly.

--- a/man/unique_id.Rd
+++ b/man/unique_id.Rd
@@ -7,7 +7,7 @@
 unique_id(x)
 }
 \arguments{
-\item{x}{any input}
+\item{x}{any input.}
 }
 \value{
 \code{x} turned into a list.

--- a/man/vctrs.Rd
+++ b/man/vctrs.Rd
@@ -109,7 +109,7 @@
 \code{vec_cast()}, \code{vec_cast_default()}, and \code{vec_restore()}, these
 dots are only for future extensions and should be empty.}
 
-\item{y}{Vectors to cast.}
+\item{y}{vectors to cast.}
 }
 \value{
 for \code{vec_cast}: the casted \code{tf}-vector, for \code{vec_ptype2}: the common prototype


### PR DESCRIPTION
- add punctuation at the EOL for `@param` and `@returns`
- streamline to lower case description and details for see details/description @fabian-s let me know if you want it in title case instead
- missing indentation (two spaces)
- missing code chunks