### PR TITLE
feat: remove glue package in favour of cli/sprintf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,12 +29,11 @@ Description: Defines S3 vector data types for vectors of functional data
 License: AGPL (>= 3)
 URL: https://tidyfun.github.io/tf/, https://github.com/tidyfun/tf/
 BugReports: https://github.com/tidyfun/tf/issues
-Depends: 
+Depends:
     R (>= 4.1)
 Imports:
     checkmate,
     cli,
-    glue,
     methods,
     mgcv,
     mvtnorm,
@@ -44,7 +43,7 @@ Imports:
     stats,
     vctrs (>= 0.2.4),
     zoo
-Suggests: 
+Suggests:
     covr,
     dplyr,
     fda,

--- a/R/ops.R
+++ b/R/ops.R
@@ -212,8 +212,8 @@ tfd_op_tfd <- function(op, x, y) {
   assert_compatible_size(op, x, y)
 
   if (!domains_overlap(x, y)) {
-    message <- glue::glue(
-      "<{vec_ptype_full(x)}> {op} <{vec_ptype_full(y)}>  not permitted for non-overlapping domains"
+    message <- cli::format_inline(
+      "<{vec_ptype_full(x)}> {op} <{vec_ptype_full(y)}> not permitted for non-overlapping domains"
     )
     stop_incompatible_op(op, x, y, message = message)
   }
@@ -234,12 +234,12 @@ tfd_op_tfd <- function(op, x, y) {
   } else {
     arg_ret <- common_args(x, y) |> ensure_list()
     if (all(lengths(arg_ret) == 0)) {
-      message <- glue::glue(
+      message <- cli::format_inline(
         "<{vec_ptype_full(x)}> {op} <{vec_ptype_full(y)}> not possible: no common argument values."
       )
       cli::cli_abort(c(
         message,
-        "i" = "Use {.fun tf_rebase} or {.fun tf_interpolate} to change argument values."
+        "i" = "Use {.fn tf_rebase} or {.fn tf_interpolate} to change argument values."
       ))
     }
     use_x <- map2(
@@ -262,7 +262,7 @@ tfd_op_tfd <- function(op, x, y) {
   )
 
   if (!same_domain || !same_arg) {
-    message <- glue::glue(
+    message <- cli::format_inline(
       "Attempting <{vec_ptype_full(x)}> {op} <{vec_ptype_full(y)}>  for different",
       "{ifelse(same_domain, '', ' domains')}",
       "{ifelse(!same_domain & !same_arg, ' and', '')}",
@@ -270,7 +270,7 @@ tfd_op_tfd <- function(op, x, y) {
     )
     cli::cli_warn(c(
       message,
-      "i" = "Use {.fun tf_rebase} or {.fun tf_interpolate} to adjust argument values first if necessary."
+      "i" = "Use {.fn tf_rebase} or {.fn tf_interpolate} to adjust argument values first if necessary."
     ))
   }
 
@@ -402,8 +402,11 @@ tfb_plusminus_tfb <- function(op, x, y) {
     vec_data(y),
     \(x, y) do.call(op, list(e1 = x, e2 = y))
   )
-  attributes(ret) <- if (vec_size(x) >= vec_size(y)) attributes(x) else
+  attributes(ret) <- if (vec_size(x) >= vec_size(y)) {
+    attributes(x)
+  } else {
     attributes(y)
+  }
   ret
 }
 

--- a/R/split-combine.R
+++ b/R/split-combine.R
@@ -88,7 +88,7 @@ tf_combine <- function(..., strict = FALSE) {
   map(tfs, assert_tf)
   sizes <- map_int(tfs, vec_size)
   if (!all(duplicated(sizes)[-1])) {
-    cli::cli_abort("can't {.fun tf_combine} objects of different sizes")
+    cli::cli_abort("can't {.fn tf_combine} objects of different sizes")
   }
   size <- sizes[1]
 
@@ -107,7 +107,7 @@ tf_combine <- function(..., strict = FALSE) {
     max_overlap <- apply(arg_maxs, 1, \(x) is.unsorted(as.numeric(x)))
     if (any(min_overlap) || any(max_overlap)) {
       cli::cli_abort(
-        "{.fun tf_arg}-ranges of input data are not strictly ordered."
+        "{.fn tf_arg}-ranges of input data are not strictly ordered."
       )
     }
   }

--- a/R/tfb-spline.R
+++ b/R/tfb-spline.R
@@ -168,7 +168,7 @@ new_tfb_spline <- function(
   if (family$family == "gaussian" && family$link == "identity") {
     family_label <- ""
   } else {
-    family_label <- glue::glue("({family$family} with {family$link}-link)")
+    family_label <- sprintf("(%s with %s)", family$family, family$link)
   }
 
   ret <- new_vctr(


### PR DESCRIPTION
- Remove glue package since already using the the `cli::format_inline()` pattern for the error message, replaced one case to `sprintf()`
- Made the cli inline syntax for function consisten, always use .fn instead of .fun etc.