### PR TITLE
fix: print the range as [NA, NA] for vector with all missing

### DIFF
--- a/R/print-format.R
+++ b/R/print-format.R
@@ -120,7 +120,8 @@ spark_rep_tf <- function(
 #' tfd(cosine, arg = t^3)
 print.tf <- function(x, n = 6, ...) {
   domain <- tf_domain(x) |> map_chr(format, ...)
-  range <- if (allMissing(x)) c(NA, NA) else range(tf_evaluations(x), na.rm = TRUE)
+  evals <- compact(tf_evaluations(x))
+  range <- if (length(evals) > 0) range(tf_evaluations(x), na.rm = TRUE) else c(NA, NA)
   range <- range |> map_chr(format, ...) |> suppressWarnings()
   cat(paste0(
     ifelse(is_irreg(x), "irregular ", ""),
@@ -148,7 +149,8 @@ print.tfd_reg <- function(x, n = 6, ...) {
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   len <- length(x)
   if (len > 0) {
-    scale_ <- if (allMissing(x)) NULL else range(tf_evaluations(x), na.rm = TRUE)
+    evals <- compact(tf_evaluations(x))
+    scale_ <- if (length(evals) > 0) range(evals, na.rm = TRUE) else NULL
     format(x[seq_len(min(n, len))], scale_f = scale_, prefix = TRUE, ...) |>
       cat(sep = "\n")
     if (n < len) {

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -120,8 +120,7 @@ spark_rep_tf <- function(
 #' tfd(cosine, arg = t^3)
 print.tf <- function(x, n = 6, ...) {
   domain <- tf_domain(x) |> map_chr(format, ...)
-  evals <- tf_evaluations(x)
-  range <- if (allMissing(evals)) c(NA, NA) else range(evals, na.rm = TRUE)
+  range <- if (allMissing(x)) c(NA, NA) else range(tf_evaluations(x), na.rm = TRUE)
   range <- range |> map_chr(format, ...) |> suppressWarnings()
   cat(paste0(
     ifelse(is_irreg(x), "irregular ", ""),
@@ -149,7 +148,7 @@ print.tfd_reg <- function(x, n = 6, ...) {
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   len <- length(x)
   if (len > 0) {
-    scale_ <- range(tf_evaluations(x), na.rm = TRUE)
+    scale_ <- if (allMissing(x)) NULL else range(tf_evaluations(x), na.rm = TRUE)
     format(x[seq_len(min(n, len))], scale_f = scale_, prefix = TRUE, ...) |>
       cat(sep = "\n")
     if (n < len) {
@@ -226,7 +225,7 @@ format.tf <- function(
   prefix = FALSE,
   ...
 ) {
-  if (is_irreg(x) || !cli::is_utf8_output() || !sparkline) {
+  if (is_irreg(x) || allMissing(x) || !cli::is_utf8_output() || !sparkline) {
     resolution <- get_resolution(tf_arg(x))
     signif_arg <- abs(floor(log10(resolution)))
     str <- string_rep_tf(

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -119,10 +119,10 @@ spark_rep_tf <- function(
 #' #! very non-equidistant grids --> sparklines can mislead about actual shapes:
 #' tfd(cosine, arg = t^3)
 print.tf <- function(x, n = 6, ...) {
-  domain <- tf_domain(x) |> sapply(format, ...)
-  range <- range(tf_evaluations(x), na.rm = TRUE) |>
-    sapply(format, ...) |>
-    suppressWarnings()
+  domain <- tf_domain(x) |> map_chr(format, ...)
+  evals <- tf_evaluations(x)
+  range <- if (allMissing(evals)) c(NA, NA) else range(evals, na.rm = TRUE)
+  range <- range |> map_chr(format, ...) |> suppressWarnings()
   cat(paste0(
     ifelse(is_irreg(x), "irregular ", ""),
     class(x)[2],

--- a/R/print-format.R
+++ b/R/print-format.R
@@ -120,8 +120,8 @@ spark_rep_tf <- function(
 #' tfd(cosine, arg = t^3)
 print.tf <- function(x, n = 6, ...) {
   domain <- tf_domain(x) |> map_chr(format, ...)
-  evals <- compact(tf_evaluations(x))
-  range <- if (length(evals) > 0) range(tf_evaluations(x), na.rm = TRUE) else c(NA, NA)
+  evals <- unlist(tf_evaluations(x), use.names = FALSE)
+  range <- if (!is.null(evals)) range(tf_evaluations(x), na.rm = TRUE) else c(NA, NA)
   range <- range |> map_chr(format, ...) |> suppressWarnings()
   cat(paste0(
     ifelse(is_irreg(x), "irregular ", ""),
@@ -149,8 +149,8 @@ print.tfd_reg <- function(x, n = 6, ...) {
   cat("interpolation by", attr(x, "evaluator_name"), "\n")
   len <- length(x)
   if (len > 0) {
-    evals <- compact(tf_evaluations(x))
-    scale_ <- if (length(evals) > 0) range(evals, na.rm = TRUE) else NULL
+    evals <- unlist(tf_evaluations(x), use.names = FALSE)
+    scale_ <- if (!is.null(evals)) range(evals, na.rm = TRUE) else NULL
     format(x[seq_len(min(n, len))], scale_f = scale_, prefix = TRUE, ...) |>
       cat(sep = "\n")
     if (n < len) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -225,6 +225,7 @@ sort_unique <- function(x, simplify = FALSE) {
 
 data_frame0 <- function(...) data_frame(..., .name_repair = "minimal")
 
+compact <- function(x) x[as.logical(lengths(x))]
 
 # Source: <https://github.com/mlr-org/mlr3misc/blob/main/R/format_bib.R>
 # by Michel Lang (copied here Feb 2024)

--- a/R/utils.R
+++ b/R/utils.R
@@ -225,8 +225,6 @@ sort_unique <- function(x, simplify = FALSE) {
 
 data_frame0 <- function(...) data_frame(..., .name_repair = "minimal")
 
-compact <- function(x) x[as.logical(lengths(x))]
-
 # Source: <https://github.com/mlr-org/mlr3misc/blob/main/R/format_bib.R>
 # by Michel Lang (copied here Feb 2024)
 format_bib <- function(..., bibentries = NULL, envir = parent.frame()) {


### PR DESCRIPTION
@fabian-s check if you like this, this makes the range to [NA, NA] copying the behaviour of range(NA) -> c(NA, NA)

before:

```r
library(tf, warn.conflicts = FALSE)

x <- tf_rgp(3)
x[1:3] <- NA
x
#> tfd[3]: [0,1] -> [Inf,-Inf] based on 51 evaluations each
#> interpolation by tf_approx_linear
#> Warning in min(x, na.rm = na.rm): no non-missing arguments to min; returning
#> Inf
#> Warning in max(x, na.rm = na.rm): no non-missing arguments to max; returning
#> -Inf
#> 1: NA
#> 2: NA
#> 3: NA
```

after:

``` r
library(tf, warn.conflicts = FALSE)

x <- tf_rgp(3)
x[1:3] <- NA
x
#> tfd[3]: [0,1] -> [NA,NA] based on 51 evaluations each
#> interpolation by tf_approx_linear
#> Warning in min(x, na.rm = na.rm): no non-missing arguments to min; returning
#> Inf
#> Warning in max(x, na.rm = na.rm): no non-missing arguments to max; returning
#> -Inf
#> 1: NA
#> 2: NA
#> 3: NA
```

<sup>Created on 2025-07-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>