### PR TITLE
Fix constructor/setter integrity bugs (#234, #235, #241)

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -189,7 +189,12 @@ tf_basis <- function(f, as_tfd = FALSE) {
 #' @export
 `tf_arg<-.tfd_irreg` <- function(x, value) {
   assert_arg(value, x, check_unique = FALSE)
-  ret <- map2(tf_evaluations(x), value, \(x, y) list(arg = y, data = x))
+  value <- ensure_list(value)
+  if (length(value) == 1) value <- rep(value, length(x))
+  ret <- map2(tf_evaluations(x), value, \(v, y) {
+    if (is.null(v)) return(NULL)
+    list(arg = y, value = v)
+  })
   attributes(ret) <- attributes(x)
   ret
 }

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -58,6 +58,34 @@ new_tfd <- function(
   assert_string(evaluator)
   assert_function(evaluator_f, args = c("x", "arg", "evaluations"), nargs = 3)
 
+  # arg/datalist length invariant: regular -> shared arg (list of length 1);
+  # irregular -> per-entry arg list (length 1 = shared, or length n).
+  # Every non-NA data entry must have length matching its arg vector.
+  arg_list <- ensure_list(arg)
+  if (
+    length(arg_list) != 1 && length(arg_list) != length(datalist)
+  ) {
+    cli::cli_abort(
+      "Length of {.arg arg} list ({length(arg_list)}) must be 1 or match length of {.arg data} ({length(datalist)})."
+    )
+  }
+  arg_lens <- lengths(arg_list)
+  data_lens <- lengths(datalist)
+  bad <- map_lgl(seq_along(datalist), \(i) {
+    x <- datalist[[i]]
+    if (is.null(x) || allMissing(x)) return(FALSE)
+    expected <- if (length(arg_list) == 1) arg_lens[1] else arg_lens[i]
+    length(x) != expected
+  })
+  if (any(bad)) {
+    bad_idx <- which(bad)
+    cli::cli_abort(c(
+      "Lengths of {.arg arg} do not match lengths of {.arg data} entries.",
+      i = "Mismatched entries at indices: {.val {bad_idx}}.",
+      i = "Data lengths there: {.val {data_lens[bad]}}."
+    ))
+  }
+
   # sort args and values by arg:
   arg_o <- map(arg, order)
   arg <- map2(arg, arg_o, \(x, y) x[y])
@@ -282,20 +310,38 @@ tfd.list <- function(
     where_na <- map(data, is.na)
     data <- map2(data, where_na, \(x, y) x[!y])
     lens <- lengths(data)
-    empty <- lens != 0
-    regular <- all(lens[!empty] == lens[!empty][1]) &
-      (is.numeric(arg) || all(duplicated(arg)[-1]))
+    nonempty <- lens != 0
+    # arg-length probe: derive the shared arg-vector length (if any) we'd
+    # use in the regular path; if it doesn't match the (post-NA-strip) data
+    # entries, the data is in fact irregular and must take the per-entry path.
+    arg_shared_len <- if (is.numeric(arg)) {
+      length(arg)
+    } else if (is.list(arg) && length(arg) == 1) {
+      length(arg[[1]])
+    } else {
+      NA_integer_
+    }
+    arg_lens_ok <- is.na(arg_shared_len) ||
+      all(lens[nonempty] == arg_shared_len)
+    regular <- all(lens[nonempty] == lens[nonempty][1]) &
+      (is.numeric(arg) || all(duplicated(arg)[-1])) &
+      arg_lens_ok
     # duplicated(NULL) == TRUE!
     if (!regular) {
       if (is.null(arg)) {
         cli::cli_abort("{.arg arg} cannot be NULL")
+      }
+      # expand a shared arg-vector to a per-entry list before NA-stripping
+      if (is.numeric(arg) || (is.list(arg) && length(arg) == 1)) {
+        arg_vec <- if (is.numeric(arg)) arg else arg[[1]]
+        arg <- rep(list(arg_vec), length(data))
       }
       if (length(arg) != length(data)) {
         cli::cli_abort(
           "Length of {.arg arg} list does not match {.arg data} list."
         )
       }
-      if (any(lengths(arg)[!empty] != lengths(where_na)[!empty])) {
+      if (any(lengths(arg)[nonempty] != lengths(where_na)[nonempty])) {
         cli::cli_abort(
           "Lengths of {.arg arg} vectors do not match lengths of {.arg data} list entries."
         )

--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -36,17 +36,53 @@ new_tfd <- function(
     evaluator_f <- get(evaluator, mode = "function", envir = parent.frame())
   }
 
-  if (
-    vec_size(datalist) == 0 || allMissing(unlist(datalist, use.names = FALSE))
-  ) {
+  # Truly empty input -> length-0 prototype. The sentinel domain
+  # `c(NA_real_, NA_real_)` matches the S4 prototype in R/tf-s4.R and avoids
+  # the `unique = TRUE` violation that `numeric(2)` (= c(0, 0)) would cause
+  # if a downstream caller ran `assert_arg` against it. "Truly empty" means
+  # either size 0 or every entry is a length-0 *numeric* vector (no NULLs --
+  # NULL is the in-vector representation of an NA function and must survive).
+  truly_empty <- vec_size(datalist) == 0 || (
+    !any(map_lgl(datalist, is.null)) && all(lengths(datalist) == 0L)
+  )
+  if (truly_empty) {
     arg <- arg %||% list(numeric())
-    domain <- domain %||% numeric(2)
+    domain <- domain %||% c(NA_real_, NA_real_)
     subclass <- if (regular) "tfd_reg" else "tfd_irreg"
     datalist <- list()
-    # message("empty or missing input `data`; returning prototype of length 0")
     ret <- new_vctr(
       datalist,
       arg = arg,
+      domain = domain,
+      evaluator = evaluator_f,
+      evaluator_name = evaluator,
+      class = c(subclass, "tfd", "tf")
+    )
+    return(ret)
+  }
+
+  # All-NA input with size > 0: produce a length-n vector of NA functions
+  # rather than silently collapsing to length 0.
+  if (allMissing(unlist(datalist, use.names = FALSE))) {
+    n <- vec_size(datalist)
+    arg_list <- if (is.null(arg)) {
+      list(seq_len(max(lengths(datalist), 1L)))
+    } else {
+      ensure_list(arg)
+    }
+    domain <- domain %||% range(unlist(arg_list, use.names = FALSE))
+    if (!is.finite(domain[1]) || !is.finite(domain[2]) || domain[1] == domain[2]) {
+      domain <- c(NA_real_, NA_real_)
+    }
+    subclass <- if (regular) "tfd_reg" else "tfd_irreg"
+    # All entries are NA, so each becomes a NULL placeholder (tf's NA representation)
+    null_data <- vector("list", n)
+    names(null_data) <- names(datalist)
+    warn_na_entries_created(seq_len(n))
+    arg_attr <- if (regular) list(arg_list[[1]]) else numeric(0)
+    ret <- new_vctr(
+      null_data,
+      arg = arg_attr,
       domain = domain,
       evaluator = evaluator_f,
       evaluator_name = evaluator,

--- a/tests/testthat/test-arg-setter.R
+++ b/tests/testthat/test-arg-setter.R
@@ -1,0 +1,33 @@
+test_that("tf_arg<-.tfd_irreg preserves values on round-trip (#234)", {
+  set.seed(1234)
+  x <- tf_sparsify(tf_rgp(2))
+  evals_before <- tf_evaluations(x)
+  arg_before <- tf_arg(x)
+  suppressWarnings(tf_arg(x) <- tf_arg(x))
+  expect_identical(tf_evaluations(x), evals_before)
+  expect_identical(tf_arg(x), arg_before)
+})
+
+test_that("tf_arg<-.tfd_irreg keeps NA entries as NULL (#234)", {
+  set.seed(99)
+  x <- tf_sparsify(tf_rgp(3))
+  # zero out one entry via arithmetic with NA to produce a NULL entry
+  x_with_na <- x + c(0, NA_real_, 0)
+  na_mask_before <- is.na(x_with_na)
+  suppressWarnings(tf_arg(x_with_na) <- tf_arg(x_with_na))
+  expect_identical(is.na(x_with_na), na_mask_before)
+})
+
+test_that("tf_arg<-.tfd_irreg accepts a single shared arg vector (#234)", {
+  x <- tfd(
+    list(c(1, 2, 3), c(4, 5, 6)),
+    arg = list(c(0, 0.5, 1), c(0, 0.5, 1))
+  )
+  x <- as.tfd_irreg(x)
+  new_arg <- c(0.1, 0.5, 0.9)
+  suppressWarnings(tf_arg(x) <- new_arg)
+  expect_identical(tf_arg(x)[[1]], new_arg)
+  expect_identical(tf_arg(x)[[2]], new_arg)
+  expect_equal(tf_evaluations(x)[[1]], c(1, 2, 3))
+  expect_equal(tf_evaluations(x)[[2]], c(4, 5, 6))
+})

--- a/tests/testthat/test-tfd-class.R
+++ b/tests/testthat/test-tfd-class.R
@@ -120,3 +120,24 @@ test_that("NA creation warning uses singular/plural wording and lists indices", 
     "Affected indices: 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, \\.{3}"
   )
 })
+
+test_that("tfd.list errors on mismatched per-entry lengths (#235)", {
+  # different lengths with shared arg -> must not silently return tfd_reg
+  expect_error(
+    tfd(list(1:3, 1:5), arg = 1:5),
+    "arg"
+  )
+  # different lengths and arg list -> irregular path catches it
+  expect_error(
+    tfd(list(1:3, 1:5), arg = list(1:3, 1:4)),
+    "do not match"
+  )
+})
+
+test_that("tfd.list infers irregular when lengths differ but arg list matches (#235)", {
+  f <- tfd(list(1:3, 1:5), arg = list(1:3, 1:5))
+  expect_s3_class(f, "tfd_irreg")
+  expect_length(f, 2)
+  expect_equal(tf_evaluations(f)[[1]], 1:3)
+  expect_equal(tf_evaluations(f)[[2]], 1:5)
+})

--- a/tests/testthat/test-tfd-class.R
+++ b/tests/testthat/test-tfd-class.R
@@ -20,25 +20,26 @@ test_that("tfd.numeric works", {
   expect_function(attr(f, "evaluator"), args = c("x", "arg", "evaluations"))
   expect_identical(attr(f, "evaluator_name"), "tf_approx_linear")
 
-  # empty data
+  # empty data: length-0 prototype with NA sentinel domain
   f <- tfd(numeric())
   expect_s3_class(f, "tfd_reg")
   expect_length(f, 0)
   expect_identical(attr(f, "arg"), list(integer()))
-  expect_identical(attr(f, "domain"), c(0, 0))
+  expect_identical(attr(f, "domain"), c(NA_real_, NA_real_))
   expect_function(attr(f, "evaluator"), args = c("x", "arg", "evaluations"))
   expect_identical(attr(f, "evaluator_name"), "tf_approx_linear")
 
-  # single NA
+  # single NA -> length-1 vector of NA functions (#241)
   for (x in list(NA_real_, NA_integer_)) {
-    f <- tfd(x)
+    f <- suppressWarnings(tfd(x))
     expect_s3_class(f, "tfd_reg")
-    expect_length(f, 0)
-    expect_identical(attr(f, "arg"), list(1L))
-    expect_identical(attr(f, "domain"), c(0, 0))
+    expect_length(f, 1)
+    expect_true(is.na(f))
     expect_function(attr(f, "evaluator"), args = c("x", "arg", "evaluations"))
     expect_identical(attr(f, "evaluator_name"), "tf_approx_linear")
   }
+  # warn on NA-only input
+  expect_warning(tfd(NA_real_), "NA")
 
   # evaluations must be inside the domain
   x <- 1:10
@@ -132,6 +133,27 @@ test_that("tfd.list errors on mismatched per-entry lengths (#235)", {
     tfd(list(1:3, 1:5), arg = list(1:3, 1:4)),
     "do not match"
   )
+})
+
+test_that("all-NA input yields length-n NA functions, not length-0 (#241)", {
+  # vector of NAs
+  x <- rep(NA_real_, 3)
+  expect_warning(f <- tfd(x), "NA")
+  expect_s3_class(f, "tfd")
+  expect_length(f, 1) # one curve, all NA evaluations
+  expect_true(is.na(f))
+
+  # matrix with all-NA rows -> one NA function per row
+  m <- matrix(NA_real_, nrow = 3, ncol = 5)
+  expect_warning(f <- tfd(m, arg = 1:5), "NA")
+  expect_length(f, 3)
+  expect_true(all(is.na(f)))
+})
+
+test_that("tfd() length-0 prototype uses NA sentinel domain (#241)", {
+  f <- tfd(numeric())
+  expect_identical(attr(f, "domain"), c(NA_real_, NA_real_))
+  expect_length(f, 0)
 })
 
 test_that("tfd.list infers irregular when lengths differ but arg list matches (#235)", {


### PR DESCRIPTION
Three constructor / setter integrity bugs.

- Closes #234 — `tf_arg<-.tfd_irreg` was building `list(arg=, data=)` instead of `list(arg=, value=)`, silently destroying all function values on a no-op round-trip.
- Closes #235 — `tfd.list` regularity check was logically inverted (`empty <- lens != 0` was the *non*-empty mask), silently NA-padding mismatched-length curves. `new_tfd()` now asserts per-entry `length(arg) == length(data)`.
- Closes #241 — All-NA `tfd()` input no longer silently returns a length-0 vector; produces a length-n vector of NA functions. Prototype `domain` reconciled to `c(NA_real_, NA_real_)` to match the S4 prototype and avoid the constructor's own `unique=TRUE` assertion.

`devtools::test()` clean (PASS 1972).

Background: part of the [June-2026 ground-up review](https://github.com/tidyfun/tf/blob/claude/ground-up-review/attic/design/ground-up-review-2026-06.md). One follow-up filed: #262 (all-NA *list* input still collapses; matrix path is correct).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_