### PR TITLE
Fix evaluation &amp; calculus path bugs (#236, #237, #246, #253)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # tf 0.4.2
 
+## Bug fixes
+
+* `tf_evaluate()` no longer returns values at the wrong positions when the
+  requested arg contains duplicates (#236).
+* `tf_integrate(f, definite = FALSE)` for irregular `tfd` with n > 1 no longer
+  crashes; the antiderivative's per-curve grids are kept as a list (#237).
+* `Math.tfd()` / `Math.tfb()` now forward `...` to the underlying op so
+  `round(x, digits)`, `log(x, base)`, `signif(x, digits)`, etc. honor their
+  extra arguments instead of silently dropping them (#246).
+* `tf_integrate()` on irregular `tfd` no longer silently returns `NA` under
+  default limits; for irregular input the defaults are now each curve's own
+  `range(tf_arg)`. Pass explicit `lower` / `upper` (or an extrapolating
+  evaluator) to override (#253).
+
 ## New features
 
 * `tfb_mfpc()` implements multivariate functional principal component analysis

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,8 @@
   extra arguments instead of silently dropping them (#246).
 * `tf_integrate()` on irregular `tfd` no longer silently returns `NA` under
   default limits; for irregular input the defaults are now each curve's own
-  `range(tf_arg)`. Pass explicit `lower` / `upper` (or an extrapolating
-  evaluator) to override (#253).
+  observed arg range (i.e., the range of its `tf_arg()` values). Pass explicit
+  `lower` / `upper` (or an extrapolating evaluator) to override (#253).
 
 ## New features
 

--- a/R/approx.R
+++ b/R/approx.R
@@ -1,5 +1,4 @@
 zoo_wrapper <- function(f, ...) {
-  #nocov start
   dots <- list(...)
   function(x, arg, evaluations) {
     x_arg <- sort_unique(c(x, arg))
@@ -9,7 +8,6 @@ zoo_wrapper <- function(f, ...) {
     ret <- do.call(f, dots)
     coredata(ret)[requested]
   }
-  #nocov end
 }
 
 #-------------------------------------------------------------------------------

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -309,8 +309,9 @@ tf_derive.tfb_fpc <- function(f, arg = tf_arg(f), order = 1, ...) {
 #'   anti-derivatives
 #' @details
 #' When `f` is irregular **and** `lower` / `upper` are not supplied explicitly,
-#' they default to each curve's own `range(tf_arg)` rather than the (shared)
-#' domain endpoints; for regular `tfd` the defaults remain the domain endpoints.
+#' they default to each curve's own observed arg range (i.e., the range of its
+#' `tf_arg()` values) rather than the (shared) domain endpoints; for regular `tfd`
+#' the defaults remain the domain endpoints.
 #' Without this per-curve default, curves that do not span the full domain
 #' would silently NA-poison the trapezoidal sum, because the default linear
 #' evaluator does not extrapolate. Pass explicit `lower` / `upper` to integrate

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -307,6 +307,14 @@ tf_derive.tfb_fpc <- function(f, arg = tf_arg(f), order = 1, ...) {
 #' @returns For `definite = TRUE`, the definite integrals of the functions in
 #'   `f`. For `definite = FALSE` and `tf`-inputs, a `tf` object containing their
 #'   anti-derivatives
+#' @details
+#' For irregular `tfd` inputs, the default `lower`/`upper` are the per-curve
+#' `range(tf_arg)` rather than the (shared) domain endpoints. Otherwise, when
+#' curves do not span the full domain, the default linear evaluator (which does
+#' not extrapolate) would return `NA` at the boundaries and silently
+#' NA-poison the trapezoidal sum. Pass explicit `lower` / `upper` to integrate
+#' over a fixed sub-interval, or switch to an extrapolating evaluator
+#' (e.g. [tf_approx_fill_extend()]) to integrate over the full domain.
 #' @examples
 #' arg <- seq(0, 1, length.out = 11)
 #' x <- tfd(rbind(arg, arg^2), arg = arg)
@@ -335,12 +343,26 @@ tf_integrate.tfd <- function(
 ) {
   assert_arg(arg, f)
   arg <- ensure_list(arg)
-  # TODO: integrate is NA whenever arg does not cover entire domain!
+  default_lower <- missing(lower)
+  default_upper <- missing(upper)
   assert_limit(lower, f)
   assert_limit(upper, f)
+  if (is_irreg(f) && (default_lower || default_upper)) {
+    # For irregular data, the default linear evaluator does not extrapolate.
+    # Using global domain endpoints when curves don't reach them yields NA
+    # for the boundary evaluations and NA-poisoned integrals. Fall back to
+    # each curve's own arg range for any defaulted limit.
+    per_curve_range <- map(ensure_list(tf_arg(f)), range)
+    if (default_lower) {
+      lower <- map_dbl(per_curve_range, 1)
+    }
+    if (default_upper) {
+      upper <- map_dbl(per_curve_range, 2)
+    }
+  }
   limits <- cbind(lower, upper)
   if (nrow(limits) > 1) {
-    if (!definite) .NotYetImplemented() # needs vd-data
+    if (!definite && !is_irreg(f)) .NotYetImplemented() # needs vd-data
     limits <- limits |> split(seq_len(nrow(limits)))
   }
   arg <- map2(
@@ -401,10 +423,18 @@ tf_integrate.tfd <- function(
     # for irregular `f`, `arg` holds per-curve grids and must stay a list;
     # flattening would yield an unsorted vector and fail `tfd.list`'s checks.
     arg_out <- if (length(arg) == 1) arg[[1]] else arg
+    # with per-curve limits (irregular f, default args) `limits` is a list of
+    # 2-vectors; collapse to a single [min(lower), max(upper)] domain.
+    domain_out <- if (is.list(limits)) {
+      lims <- do.call(rbind, limits)
+      c(min(lims[, 1]), max(lims[, 2]))
+    } else {
+      as.numeric(limits)
+    }
     tfd(
       data = data_list,
       arg = arg_out,
-      domain = as.numeric(limits),
+      domain = domain_out,
       evaluator = !!attr(f, "evaluator_name")
     )
   }

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -398,9 +398,12 @@ tf_integrate.tfd <- function(
   } else {
     data_list <- map(quads, cumsum)
     names(data_list) <- names(f)
+    # for irregular `f`, `arg` holds per-curve grids and must stay a list;
+    # flattening would yield an unsorted vector and fail `tfd.list`'s checks.
+    arg_out <- if (length(arg) == 1) arg[[1]] else arg
     tfd(
       data = data_list,
-      arg = unlist(arg, use.names = FALSE),
+      arg = arg_out,
       domain = as.numeric(limits),
       evaluator = !!attr(f, "evaluator_name")
     )

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -308,11 +308,12 @@ tf_derive.tfb_fpc <- function(f, arg = tf_arg(f), order = 1, ...) {
 #'   `f`. For `definite = FALSE` and `tf`-inputs, a `tf` object containing their
 #'   anti-derivatives
 #' @details
-#' For irregular `tfd` inputs, the default `lower`/`upper` are the per-curve
-#' `range(tf_arg)` rather than the (shared) domain endpoints. Otherwise, when
-#' curves do not span the full domain, the default linear evaluator (which does
-#' not extrapolate) would return `NA` at the boundaries and silently
-#' NA-poison the trapezoidal sum. Pass explicit `lower` / `upper` to integrate
+#' When `f` is irregular **and** `lower` / `upper` are not supplied explicitly,
+#' they default to each curve's own `range(tf_arg)` rather than the (shared)
+#' domain endpoints; for regular `tfd` the defaults remain the domain endpoints.
+#' Without this per-curve default, curves that do not span the full domain
+#' would silently NA-poison the trapezoidal sum, because the default linear
+#' evaluator does not extrapolate. Pass explicit `lower` / `upper` to integrate
 #' over a fixed sub-interval, or switch to an extrapolating evaluator
 #' (e.g. [tf_approx_fill_extend()]) to integrate over the full domain.
 #' @examples

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -73,8 +73,15 @@ evaluate_tfd_once <- function(
   seen <- !is.na(seen)
   ret <- rep(NA_real_, length(new_arg))
   ret[seen] <- evaluations[seen_index]
-  ret[!seen] <-
-    evaluator(new_arg[!seen], arg = arg, evaluations = evaluations)
+  if (any(!seen)) {
+    # evaluator may sort/uniquify its input (see zoo_wrapper); evaluate on
+    # the unique sorted unseen args, then map back so duplicated `new_arg`
+    # values land at the correct positions.
+    unseen <- new_arg[!seen]
+    u <- sort_unique(unseen)
+    vals <- evaluator(u, arg = arg, evaluations = evaluations)
+    ret[!seen] <- vals[match(unseen, u)]
+  }
   ret
 }
 

--- a/R/math.R
+++ b/R/math.R
@@ -1,10 +1,11 @@
 # utility function for linear operations that can be done on coefs or
 #   evaluations directly.
-fun_math <- function(x, op) {
+fun_math <- function(x, op, ...) {
   attr_ret <- attributes(x)
+  dots <- list(...)
   ret <- map(tf_evaluations(x), \(x) {
     if (is.null(x)) return(NULL)
-    result <- do.call(op, list(x = x))
+    result <- do.call(op, c(list(x = x), dots))
     if (allMissing(result)) NULL else result
   })
   if (is_irreg(x)) {
@@ -25,7 +26,7 @@ NULL
 #' @export
 #' @family tidyfun compute functions
 Math.tfd <- function(x, ...) {
-  fun_math(x, .Generic)
+  fun_math(x, .Generic, ...)
 }
 
 #' @rdname tfgroupgenerics
@@ -36,7 +37,7 @@ Math.tfb <- function(x, ...) {
     "Potentially lossy cast to {.cls tfd} and back in {.fn {genericname}}({.cls {vec_ptype_full(x)}})."
   )
   basis_args <- attr(x, "basis_args")
-  eval <- fun_math(tfd(x), .Generic)
+  eval <- fun_math(tfd(x), .Generic, ...)
   na_entries <- is.na(eval)
   if (all(na_entries)) {
     # all entries became NA -- return tfb with NULL entries

--- a/man/tf_integrate.Rd
+++ b/man/tf_integrate.Rd
@@ -59,6 +59,15 @@ alternatively for \code{definite = FALSE} the \emph{anti-derivative} on
 \verb{[lower, upper]}, e.g. a \code{tfd} or \code{tfb} object representing \eqn{F(t) \approx
 \int^{t}_{lower}f(s)ds}, for \eqn{t \in}\verb{[lower, upper]}, is returned.
 }
+\details{
+For irregular \code{tfd} inputs, the default \code{lower}/\code{upper} are the per-curve
+\code{range(tf_arg)} rather than the (shared) domain endpoints. Otherwise, when
+curves do not span the full domain, the default linear evaluator (which does
+not extrapolate) would return \code{NA} at the boundaries and silently
+NA-poison the trapezoidal sum. Pass explicit \code{lower} / \code{upper} to integrate
+over a fixed sub-interval, or switch to an extrapolating evaluator
+(e.g. \code{\link[=tf_approx_fill_extend]{tf_approx_fill_extend()}}) to integrate over the full domain.
+}
 \examples{
 arg <- seq(0, 1, length.out = 11)
 x <- tfd(rbind(arg, arg^2), arg = arg)

--- a/man/tf_integrate.Rd
+++ b/man/tf_integrate.Rd
@@ -61,7 +61,7 @@ alternatively for \code{definite = FALSE} the \emph{anti-derivative} on
 }
 \details{
 For irregular \code{tfd} inputs, the default \code{lower}/\code{upper} are the per-curve
-\code{range(tf_arg)} rather than the (shared) domain endpoints. Otherwise, when
+range of each curve's \code{tf_arg()} values rather than the (shared) domain endpoints. Otherwise, when
 curves do not span the full domain, the default linear evaluator (which does
 not extrapolate) would return \code{NA} at the boundaries and silently
 NA-poison the trapezoidal sum. Pass explicit \code{lower} / \code{upper} to integrate

--- a/tests/testthat/test-approx.R
+++ b/tests/testthat/test-approx.R
@@ -1,0 +1,61 @@
+test_that("tf_approx_linear interpolates and returns NA outside", {
+  res <- tf_approx_linear(
+    x = c(-0.1, 0, 0.25, 0.5, 1, 1.1),
+    arg = c(0, 0.5, 1),
+    evaluations = c(0, 1, 2)
+  )
+  expect_equal(res[2:5], c(0, 0.5, 1, 2))
+  expect_true(is.na(res[1]) && is.na(res[6]))
+})
+
+test_that("tf_approx_spline interpolates linear data exactly", {
+  arg <- seq(0, 1, length.out = 11)
+  evals <- 2 * arg + 1
+  res <- tf_approx_spline(x = c(0.05, 0.27, 0.95), arg = arg, evaluations = evals)
+  expect_equal(res, 2 * c(0.05, 0.27, 0.95) + 1, tolerance = 1e-8)
+})
+
+test_that("tf_approx_none returns NA at unseen args, passes through seen ones", {
+  res <- tf_approx_none(
+    x = c(0, 0.25, 0.5, 1),
+    arg = c(0, 0.5, 1),
+    evaluations = c(0, 1, 2)
+  )
+  expect_equal(res[c(1, 3, 4)], c(0, 1, 2))
+  expect_true(is.na(res[2]))
+})
+
+test_that("tf_approx_fill_extend extrapolates with boundary values", {
+  res <- tf_approx_fill_extend(
+    x = c(-0.5, 0, 0.5, 1, 2),
+    arg = c(0, 1),
+    evaluations = c(3, 7)
+  )
+  expect_equal(res, c(3, 3, 5, 7, 7))
+})
+
+test_that("tf_approx_locf carries last observation forward", {
+  res <- tf_approx_locf(
+    x = c(0, 0.3, 0.5, 0.7, 1),
+    arg = c(0, 0.5, 1),
+    evaluations = c(10, 20, 30)
+  )
+  expect_equal(res, c(10, 10, 20, 20, 30))
+})
+
+test_that("tf_approx_nocb carries next observation backward", {
+  res <- tf_approx_nocb(
+    x = c(0, 0.3, 0.5, 0.7, 1),
+    arg = c(0, 0.5, 1),
+    evaluations = c(10, 20, 30)
+  )
+  expect_equal(res, c(10, 20, 20, 30, 30))
+})
+
+test_that("evaluators are wired up via tf_evaluator<- on tfd", {
+  x <- tfd(matrix(c(0, 1, 2), nrow = 1), arg = c(0, 0.5, 1),
+           domain = c(-1, 2))
+  expect_true(is.na(as.numeric(x[, 1.5])))
+  tf_evaluator(x) <- tf_approx_fill_extend
+  expect_equal(as.numeric(x[, 1.5]), 2)
+})

--- a/tests/testthat/test-calculus.R
+++ b/tests/testthat/test-calculus.R
@@ -190,3 +190,17 @@ test_that("derivative at extremum is near zero", {
   f_deriv <- tf_derive(f_quad)
   expect_equal(as.numeric(f_deriv[, 2]), 0, tolerance = 1e-4)
 })
+
+test_that("tf_integrate antiderivative for irregular tfd does not crash (#237)", {
+  set.seed(11)
+  f <- tf_sparsify(tf_rgp(3))
+  anti <- expect_no_error(tf_integrate(f, definite = FALSE))
+  expect_s3_class(anti, "tfd")
+  expect_length(anti, length(f))
+  # cumsum-based antiderivative starts at 0 at each curve's first arg
+  expect_equal(
+    vapply(tf_evaluations(anti), `[`, numeric(1), 1),
+    rep(0, length(anti)),
+    ignore_attr = TRUE
+  )
+})

--- a/tests/testthat/test-calculus.R
+++ b/tests/testthat/test-calculus.R
@@ -204,3 +204,15 @@ test_that("tf_integrate antiderivative for irregular tfd does not crash (#237)",
     ignore_attr = TRUE
   )
 })
+test_that("tf_integrate definite for irregular tfd is non-NA under defaults (#253)", {
+  set.seed(11)
+  f <- tf_sparsify(tf_rgp(3))
+  res <- expect_no_warning(tf_integrate(f))
+  expect_true(all(!is.na(res)))
+  # compare to explicit per-curve limits: should agree exactly
+  ranges <- lapply(tf_arg(f), range)
+  lo <- vapply(ranges, `[`, numeric(1), 1)
+  up <- vapply(ranges, `[`, numeric(1), 2)
+  res_explicit <- tf_integrate(f, lower = lo, upper = up)
+  expect_equal(unname(res), unname(res_explicit))
+})

--- a/tests/testthat/test-evaluate.R
+++ b/tests/testthat/test-evaluate.R
@@ -49,3 +49,20 @@ test_that("tf_evaluate.tfb keeps NA entries for shared arg", {
   expect_length(eval_grid, length(b_na))
   expect_equal(eval_grid[[2]], rep(NA_real_, 5))
 })
+
+test_that("tf_evaluate.tfd returns values at correct positions for duplicated args (#236)", {
+  arg <- seq(0, 1, length.out = 11)
+  x <- tfd(matrix(arg, nrow = 1), arg = arg)
+  # duplicated unseen args must all be placed correctly
+  expect_equal(
+    tf_evaluate(x, c(0.25, 0.25, 0.35))[[1]],
+    c(0.25, 0.25, 0.35)
+  )
+  # duplicated values, all unseen, more than one duplicate
+  expect_equal(
+    tf_evaluate(x, c(0.25, 0.25, 0.35, 0.35))[[1]],
+    c(0.25, 0.25, 0.35, 0.35)
+  )
+  # `[` operator path reaches the same code
+  expect_equal(as.numeric(x[1, c(0.25, 0.25, 0.35)]), c(0.25, 0.25, 0.35))
+})

--- a/tests/testthat/test-math.R
+++ b/tests/testthat/test-math.R
@@ -1,0 +1,54 @@
+test_that("Math.tfd threads `...` to the generic (#246)", {
+  arg <- seq(0, 1, length.out = 11)
+  x <- tfd(matrix(c(1.234, 2.345, 3.456, 4.567, 5.678,
+                    6.789, 7.890, 8.901, 9.012, 10.123, 11.234), nrow = 1),
+           arg = arg)
+
+  # round honors digits arg
+  r1 <- as.numeric(round(x, 1)[, arg])
+  r0 <- as.numeric(round(x)[, arg])
+  expect_false(isTRUE(all.equal(r1, r0)))
+  expect_equal(r1, round(as.numeric(x[, arg]), 1))
+
+  # log honors base arg
+  l10 <- as.numeric(log(x, base = 10)[, arg])
+  le <- as.numeric(log(x)[, arg])
+  expect_false(isTRUE(all.equal(l10, le)))
+  expect_equal(l10, log10(as.numeric(x[, arg])))
+
+  # signif honors digits arg
+  s2 <- as.numeric(signif(x, 2)[, arg])
+  expect_equal(s2, signif(as.numeric(x[, arg]), 2))
+})
+
+test_that("Math.tfd basic ops without extra args still work", {
+  arg <- seq(0.1, 1, length.out = 10)
+  x <- tfd(matrix(arg, nrow = 1), arg = arg)
+  expect_equal(as.numeric(sqrt(x)[, arg]), sqrt(arg))
+  expect_equal(as.numeric(exp(x)[, arg]), exp(arg))
+  expect_equal(as.numeric(abs(-x)[, arg]), arg)
+})
+
+test_that("Math.tfb threads `...` (round-trip via tfd)", {
+  arg <- seq(0, 1, length.out = 51)
+  raw <- tfd(matrix(1.2345 + sin(2 * pi * arg), nrow = 1), arg = arg)
+  b <- suppressMessages({
+    capture.output(b <- tfb(raw, k = 15, penalized = FALSE, verbose = FALSE))
+    b
+  })
+  r1 <- suppressWarnings(round(b, 1))
+  r0 <- suppressWarnings(round(b))
+  expect_false(isTRUE(all.equal(
+    as.numeric(r1[, arg]),
+    as.numeric(r0[, arg])
+  )))
+})
+
+test_that("Math.tfd works on irregular tfd", {
+  irr <- tfd(list(c(1.1, 2.2, 3.3), c(2.6, 4.7)),
+             arg = list(c(0, 0.5, 1), c(0, 1)))
+  r <- round(irr, 0)
+  vals <- tf_evaluations(r)
+  expect_equal(vals[[1]], c(1, 2, 3))
+  expect_equal(vals[[2]], c(3, 5))
+})


### PR DESCRIPTION
Four evaluation- and calculus-path bugs.

- Closes #236 — `tf_evaluate` returned values at the wrong positions when the requested arg contained duplicates (`zoo_wrapper` sort+unique vs positional assignment). Evaluate on unique arg and `match()` back. Removed the `# nocov` shield around all six `tf_approx_*` evaluators.
- Closes #237 — Antiderivative of irregular `tfd` with n>1 crashed because the per-curve arg list was `unlist`-ed. Keep it as a list.
- Closes #246 — `Math.tfd` / `Math.tfb` silently dropped `...`: `round(x, 1) == round(x)`, `log(x, base = 10) == log(x)`. Thread `...` through.
- Closes #253 — `tf_integrate` silently returned `NA`s for irregular `tfd` under default limits. For irregular input under defaults, use each curve's own `range(tf_arg)`. Documented in `@details`.

`devtools::test()` clean. New test files `test-math.R` and `test-approx.R` (both previously untested). NEWS updated.

Background: part of the [June-2026 ground-up review](https://github.com/tidyfun/tf/blob/claude/ground-up-review/attic/design/ground-up-review-2026-06.md).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_