### PR TITLE
Fix `tf_mv` seam bugs (#244, #245, #252)

### DIFF
--- a/R/brackets-mv.R
+++ b/R/brackets-mv.R
@@ -76,19 +76,26 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
   comps <- tf_components(x)
   comp_names <- attr(x, "comp_names")
 
-  # If any component is basis-represented, the per-component `[.tf` would emit
-  # the "interpolate ignored" inform once per component; emit it once here
-  # and suppress the per-component calls below (#252).
-  if (!interpolate && any(map_lgl(comps, is_tfb))) {
+  # `interpolate = FALSE` is only meaningful for tfd components; tfb components
+  # are always evaluated from their basis representation. Build a per-component
+  # `interpolate` vector so we honour the user's choice for tfd components in
+  # any (potentially mixed) tf_mv, and emit the "interpolate ignored" inform
+  # at most once even when several components are basis-represented (#252).
+  comp_is_tfb <- map_lgl(comps, is_tfb)
+  if (!interpolate && any(comp_is_tfb)) {
     cli::cli_inform(
       "{.arg interpolate} ignored for data in basis representation."
     )
-    interpolate <- TRUE
   }
+  interpolate_comp <- ifelse(comp_is_tfb, TRUE, interpolate)
 
   # matrix-index i: (function, arg) pairs -> (nrow(i) x d) matrix
   if (!missing(i) && is.matrix(i)) {
-    cols <- map(comps, \(comp) comp[i, interpolate = interpolate])
+    cols <- map2(
+      comps,
+      interpolate_comp,
+      \(comp, intp) comp[i, interpolate = intp]
+    )
     ret <- do.call(cbind, cols)
     colnames(ret) <- comp_names
     return(ret)
@@ -127,9 +134,10 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
         dimnames = list(names(xi), as.character(j), comp_names)
       ))
     }
-    mats <- map(
+    mats <- map2(
       comps_i,
-      \(comp) comp[, j, interpolate = interpolate, matrix = TRUE]
+      interpolate_comp,
+      \(comp, intp) comp[, j, interpolate = intp, matrix = TRUE]
     )
     arr <- array(
       unlist(mats, use.names = FALSE),
@@ -142,9 +150,10 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
   if (!length(comps_i) || n_i == 0L) {
     return(setNames(vector("list", n_i), names(xi)))
   }
-  dfs <- map(
+  dfs <- map2(
     comps_i,
-    \(comp) comp[, j, interpolate = interpolate, matrix = FALSE]
+    interpolate_comp,
+    \(comp, intp) comp[, j, interpolate = intp, matrix = FALSE]
   )
   map(seq_len(n_i), function(k) {
     base <- dfs[[1]][[k]]
@@ -181,11 +190,19 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
       )
     }
     # Validate length upfront so we emit a clean message rather than the
-    # downstream vec_slice<- "Can't recycle" complaint.
-    if (length(value) > 1L && length(value) != length(i)) {
+    # downstream vec_slice<- "Can't recycle" complaint. Use vctrs subassignment
+    # semantics so logical / negative / named indices give the correct number
+    # of replacement locations rather than `length(i)`.
+    n_loc <- length(vec_as_location(
+      i,
+      n = vec_size(x),
+      names = names(x),
+      missing = "error"
+    ))
+    if (length(value) > 1L && length(value) != n_loc) {
       cli::cli_abort(
         "length of {.arg value} ({length(value)}) must be 1 or match \\
-        {.arg i} ({length(i)})."
+        the number of locations in {.arg i} ({n_loc})."
       )
     }
     rep(list(value), length(comps))

--- a/R/brackets-mv.R
+++ b/R/brackets-mv.R
@@ -76,6 +76,16 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
   comps <- tf_components(x)
   comp_names <- attr(x, "comp_names")
 
+  # If any component is basis-represented, the per-component `[.tf` would emit
+  # the "interpolate ignored" inform once per component; emit it once here
+  # and suppress the per-component calls below (#252).
+  if (!interpolate && any(map_lgl(comps, is_tfb))) {
+    cli::cli_inform(
+      "{.arg interpolate} ignored for data in basis representation."
+    )
+    interpolate <- TRUE
+  }
+
   # matrix-index i: (function, arg) pairs -> (nrow(i) x d) matrix
   if (!missing(i) && is.matrix(i)) {
     cols <- map(comps, \(comp) comp[i, interpolate = interpolate])
@@ -84,7 +94,19 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
     return(ret)
   }
 
-  if (missing(i)) i <- seq_along(x)
+  # Validate `i` the same way univariate `[.tf` does (no NA, no missing names,
+  # no out-of-bounds). TODO(#252): factor this and `j`-normalisation out of
+  # `[.tf` into a shared helper to remove the bracket-code duplication.
+  if (missing(i)) {
+    i <- seq_along(x)
+  } else {
+    i <- vec_as_location(
+      i,
+      n = vec_size(x),
+      names = names(x),
+      missing = "error"
+    )
+  }
   xi <- vec_slice(x, i)
 
   if (missing(j) && missing(matrix)) {

--- a/R/brackets-mv.R
+++ b/R/brackets-mv.R
@@ -170,14 +170,22 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
     check_compatible_mv(x, value)
     tf_components(value)
   } else {
-    # only NA (scalar logical/numeric, or all-NA atomic) is broadcast across
-    # every component. Anything else -- including a univariate tf -- is a
-    # type error: it would silently make every component identical.
-    is_atomic_all_na <- is.atomic(value) && length(value) &&
-      all(is.na(value))
-    if (!is_atomic_all_na) {
+    # Only logical NA is broadcast across every component. Typed NAs
+    # (NA_real_, NA_integer_) and any non-NA value -- including a univariate
+    # tf -- are rejected: they would silently make every component identical
+    # or trigger a confusing downstream "Can't combine" error.
+    is_logical_na <- is.logical(value) && length(value) && all(is.na(value))
+    if (!is_logical_na) {
       cli::cli_abort(
-        "univariate tf cannot be combined with vector-valued tf_mv"
+        "expected logical {.code NA} or another {.cls tf_mv} on the right-hand side."
+      )
+    }
+    # Validate length upfront so we emit a clean message rather than the
+    # downstream vec_slice<- "Can't recycle" complaint.
+    if (length(value) > 1L && length(value) != length(i)) {
+      cli::cli_abort(
+        "length of {.arg value} ({length(value)}) must be 1 or match \\
+        {.arg i} ({length(i)})."
       )
     }
     rep(list(value), length(comps))

--- a/R/brackets-mv.R
+++ b/R/brackets-mv.R
@@ -95,8 +95,8 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
   }
 
   # Validate `i` the same way univariate `[.tf` does (no NA, no missing names,
-  # no out-of-bounds). TODO(#252): factor this and `j`-normalisation out of
-  # `[.tf` into a shared helper to remove the bracket-code duplication.
+  # no out-of-bounds). TODO(#263): replace with a shared helper that also
+  # handles `j`-normalisation, to remove the duplication with `[.tf`.
   if (missing(i)) {
     i <- seq_along(x)
   } else {

--- a/R/brackets-mv.R
+++ b/R/brackets-mv.R
@@ -148,7 +148,16 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
     check_compatible_mv(x, value)
     tf_components(value)
   } else {
-    # a scalar (typically NA) is broadcast to every component
+    # only NA (scalar logical/numeric, or all-NA atomic) is broadcast across
+    # every component. Anything else -- including a univariate tf -- is a
+    # type error: it would silently make every component identical.
+    is_atomic_all_na <- is.atomic(value) && length(value) &&
+      all(is.na(value))
+    if (!is_atomic_all_na) {
+      cli::cli_abort(
+        "univariate tf cannot be combined with vector-valued tf_mv"
+      )
+    }
     rep(list(value), length(comps))
   }
   new_comps <- map2(comps, value_comps, function(comp, v) {

--- a/R/ops-mv.R
+++ b/R/ops-mv.R
@@ -100,26 +100,19 @@ sd.tf_mv <- function(x, na.rm = FALSE) {
 
 #' @export
 var.tf_mv <- function(x, y = NULL, na.rm = FALSE, use) {
-  has_use <- !missing(use)
-  if (!is.null(y) && is_tf_mv(y)) {
-    check_compatible_mv(x, y)
-    missing <- mv_missing(x, y)
-    x <- mv_complete(x, missing = missing, na.rm = na.rm)
-    y <- mv_complete(y, missing = missing, na.rm = na.rm)
-    return(map2_components(x, y, function(a, b) {
-      if (has_use) {
-        var(a, y = b, na.rm = na.rm, use = use)
-      } else {
-        var(a, y = b, na.rm = na.rm)
-      }
-    }))
+  if (!is.null(y)) {
+    cli::cli_abort(c(
+      "{.fn var} on {.cls tf_mv} does not support a second argument {.arg y}.",
+      "i" = "Use {.fn tf_crosscov} or {.fn tf_crosscor} for cross-(co)variance."
+    ))
   }
+  has_use <- !missing(use)
   x <- mv_complete(x, na.rm = na.rm)
   map_components(x, function(a) {
     if (has_use) {
-      var(a, y = y, na.rm = na.rm, use = use)
+      var(a, na.rm = na.rm, use = use)
     } else {
-      var(a, y = y, na.rm = na.rm)
+      var(a, na.rm = na.rm)
     }
   })
 }

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -140,6 +140,12 @@ var.default <- stats::var
 #' @export
 #' @rdname tfsummaries
 var.tf <- function(x, y = NULL, na.rm = FALSE, use) {
+  if (!is.null(y)) {
+    cli::cli_abort(c(
+      "{.fn var} on {.cls tf} does not support a second argument {.arg y}.",
+      "i" = "Use {.fn tf_crosscov} or {.fn tf_crosscor} for cross-(co)variance."
+    ))
+  }
   summarize_tf(x, na.rm = na.rm, op = "var", eval = is_tfd(x))
 }
 

--- a/tests/testthat/test-mv-edge.R
+++ b/tests/testthat/test-mv-edge.R
@@ -528,3 +528,19 @@ test_that("tf_inner.tf_mv rejects a non-tf_mv second argument informatively", {
   expect_error(tf_inner(f, tf_rgp(2)), "tf_mv")
   expect_error(tf_inner(f, 1:2), "tf_mv")
 })
+
+# ---- bracket seams: NA index, broadcast, and var() y handling ----------------
+
+test_that("[<-.tf_mv rejects a univariate tf and other non-NA scalars (#244)", {
+  set.seed(244)
+  g <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))
+  # broadcasting a univariate tf would silently corrupt every component:
+  expect_error(g[1] <- tf_rgp(1), "univariate tf")
+  # bare numeric scalars are not a valid "all components NA" sentinel either
+  expect_error(g[1] <- 0, "univariate tf")
+  # NA still works (the documented broadcast use-case)
+  g_na <- g
+  g_na[1] <- NA
+  expect_true(is.na(g_na$x[1]))
+  expect_true(is.na(g_na$y[1]))
+})

--- a/tests/testthat/test-mv-edge.R
+++ b/tests/testthat/test-mv-edge.R
@@ -557,3 +557,22 @@ test_that("var.tf and var.tf_mv error on a non-NULL y (#245)", {
   expect_s3_class(var(f), "tf")
   expect_s3_class(var(fm), "tf_mv")
 })
+
+test_that("[.tf_mv rejects NA indices and out-of-bounds (#252)", {
+  set.seed(252)
+  f <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))
+  expect_error(f[c(1, NA)], "[Mm]issing|NA")
+  expect_error(f[c(1L, NA_integer_)], "[Mm]issing|NA")
+  # out-of-bounds also errors (was already implicit via vec_slice, kept for
+  # parity with univariate `[.tf`)
+  expect_error(f[10])
+})
+
+test_that("[.tf_mv emits the basis 'interpolate ignored' inform once (#252)", {
+  set.seed(2521)
+  fb <- tfb(tf_rgp(3), verbose = FALSE)
+  fbm <- tfb_mv(list(x = fb, y = fb))
+  msgs <- capture_messages(out <- fbm[1:2, , interpolate = FALSE])
+  # exactly one inform, not one per component
+  expect_length(grep("interpolate", msgs), 1L)
+})

--- a/tests/testthat/test-mv-edge.R
+++ b/tests/testthat/test-mv-edge.R
@@ -602,3 +602,49 @@ test_that("[.tf_mv emits the basis 'interpolate ignored' inform once (#252)", {
   # exactly one inform, not one per component
   expect_length(grep("interpolate", msgs), 1L)
 })
+
+test_that("[.tf_mv honours interpolate = FALSE for tfd components (#270)", {
+  # For all-tfd tf_mv, no tfb-driven override fires, the user's
+  # `interpolate = FALSE` is honoured per component and we get the standard
+  # univariate `[.tf` NA-warning on out-of-grid j. Pinned here so the
+  # per-component override logic stays per-component rather than reverting
+  # to the old all-or-nothing global override (which would silently force
+  # interpolate = TRUE for tfd components whenever any future mixed
+  # tf_mv contains a single tfb component).
+  x <- tfd(matrix(1:3, nrow = 2, ncol = 3, byrow = TRUE), arg = 1:3)
+  y <- tfd(matrix(4:6, nrow = 2, ncol = 3, byrow = TRUE), arg = 1:3)
+  f <- tfd_mv(list(x = x, y = y))
+  msgs <- capture_messages(
+    suppressWarnings(
+      arr <- f[, c(1, 2.5), interpolate = FALSE]
+    )
+  )
+  # no 'interpolate ignored' inform when no component is basis-represented
+  expect_length(grep("interpolate ignored", msgs), 0L)
+  # 2.5 is not on the native grid -> NA under interpolate = FALSE
+  expect_true(all(is.na(arr[, "2.5", ])))
+  # 1 is on the native grid -> value preserved (= 1 for both rows of x)
+  expect_equal(unname(arr[, "1", "x"]), c(1, 1))
+})
+
+test_that("[<-.tf_mv length validation handles logical indices (#270)", {
+  set.seed(2701)
+  g <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))
+  # logical i with 2 TRUEs == 2 locations; 2 NAs should be accepted
+  g2 <- g
+  expect_no_error(g2[c(TRUE, FALSE, TRUE)] <- c(NA, NA))
+  expect_true(is.na(g2$x[1]))
+  expect_false(is.na(g2$x[2]))
+  expect_true(is.na(g2$x[3]))
+  # 2 TRUEs but 3 NAs -> length mismatch, clean tf_mv-level error
+  expect_error(
+    g[c(TRUE, FALSE, TRUE)] <- c(NA, NA, NA),
+    "length|tf_mv"
+  )
+  # negative indices: -1 = 2 locations on length-3, 2 NAs ok
+  g3 <- g
+  expect_no_error(g3[-1] <- c(NA, NA))
+  expect_false(is.na(g3$x[1]))
+  expect_true(is.na(g3$x[2]))
+  expect_true(is.na(g3$x[3]))
+})

--- a/tests/testthat/test-mv-edge.R
+++ b/tests/testthat/test-mv-edge.R
@@ -535,14 +535,40 @@ test_that("[<-.tf_mv rejects a univariate tf and other non-NA scalars (#244)", {
   set.seed(244)
   g <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))
   # broadcasting a univariate tf would silently corrupt every component:
-  expect_error(g[1] <- tf_rgp(1), "univariate tf")
+  expect_error(g[1] <- tf_rgp(1), "logical.*NA|tf_mv")
   # bare numeric scalars are not a valid "all components NA" sentinel either
-  expect_error(g[1] <- 0, "univariate tf")
+  expect_error(g[1] <- 0, "logical.*NA|tf_mv")
   # NA still works (the documented broadcast use-case)
   g_na <- g
   g_na[1] <- NA
   expect_true(is.na(g_na$x[1]))
   expect_true(is.na(g_na$y[1]))
+})
+
+test_that("[<-.tf_mv rejects typed NAs and validates length upfront (#244)", {
+  set.seed(2441)
+  g <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))
+  # Typed NAs are rejected with the new message rather than the downstream
+  # "Can't combine <double> and <tfd_reg>" complaint.
+  expect_error(g[1] <- NA_real_, "logical.*NA|tf_mv")
+  expect_error(g[1] <- NA_integer_, "logical.*NA|tf_mv")
+  # Length-mismatched all-NA value is rejected upfront with a clean message
+  # rather than the downstream vec_slice<- "Can't recycle" error.
+  expect_error(g[1] <- c(NA, NA), "length")
+  # logical(0) was already rejected; pin the behaviour.
+  expect_error(g[1] <- logical(0), "logical.*NA|tf_mv")
+})
+
+test_that("var(<tf|tf_mv>, y = NULL) explicitly works (#245)", {
+  set.seed(2451)
+  f <- tf_rgp(5)
+  fm <- tfd_mv(list(x = tf_rgp(4), y = tf_rgp(4)))
+  # passing an explicit NULL is the deliberate use case and must not error
+  expect_s3_class(var(f, y = NULL), "tf")
+  expect_s3_class(var(fm, y = NULL), "tf_mv")
+  # direct method calls too
+  expect_s3_class(var.tf(f, y = NULL), "tf")
+  expect_s3_class(var.tf_mv(fm, y = NULL), "tf_mv")
 })
 
 test_that("var.tf and var.tf_mv error on a non-NULL y (#245)", {

--- a/tests/testthat/test-mv-edge.R
+++ b/tests/testthat/test-mv-edge.R
@@ -544,3 +544,16 @@ test_that("[<-.tf_mv rejects a univariate tf and other non-NA scalars (#244)", {
   expect_true(is.na(g_na$x[1]))
   expect_true(is.na(g_na$y[1]))
 })
+
+test_that("var.tf and var.tf_mv error on a non-NULL y (#245)", {
+  set.seed(245)
+  f <- tf_rgp(5)
+  g <- tf_rgp(5)
+  expect_error(var(f, g), "tf_crosscov|tf_crosscor")
+  fm <- tfd_mv(list(x = tf_rgp(4), y = tf_rgp(4)))
+  gm <- tfd_mv(list(x = tf_rgp(4), y = tf_rgp(4)))
+  expect_error(var(fm, gm), "tf_crosscov|tf_crosscor")
+  # var(x) without y still works
+  expect_s3_class(var(f), "tf")
+  expect_s3_class(var(fm), "tf_mv")
+})


### PR DESCRIPTION
Three silent-wrongness bugs at the `tf_mv` seams.

- Closes #244 — `[<-.tf_mv` silently broadcast a univariate `tf` (or any non-`tf_mv` value) into every component. `g[1] <- tf_rgp(1)` succeeded with corrupt result. Gate restricted to `is.logical(value) && all(is.na(value))` with explicit length check; same error message as `vec_arith.tf_mv.default`.
- Closes #245 — `var(f, g)` silently ignored `g` (`var.tf` drops `y`; `var.tf_mv` plumbing was dead). Both now `cli_abort` on non-NULL `y` and point at `tf_crosscov`/`tf_crosscor`.
- Closes #252 — `[.tf_mv` silently accepted NA indices (univariate `[.tf` errors via `vec_as_location(missing = "error")`). Now consistent. Also dedupes the `interpolate = FALSE` inform message (was emitted `d` times).

Filed as follow-up: #263 — extract shared `[.tf` / `[.tf_mv` index helpers (preserving the four-mode `[.tf` design — extraction only).

`devtools::test()` clean.

Background: part of the [June-2026 ground-up review](https://github.com/tidyfun/tf/blob/claude/ground-up-review/attic/design/ground-up-review-2026-06.md).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_