### PR TITLE
Fix small isolated bugs (#247, #248, #250, #251)

### DIFF
--- a/R/graphics.R
+++ b/R/graphics.R
@@ -103,7 +103,7 @@ plot.tf <- function(
           points = TRUE,
           interpolate = FALSE,
           pch = 19,
-          ol = rgb(0, 0, 0, alpha)
+          col = rgb(0, 0, 0, alpha)
         ),
         list(...)
       )

--- a/R/split-combine.R
+++ b/R/split-combine.R
@@ -31,17 +31,20 @@ tf_split <- function(x, splits, include = c("both", "left", "right")) {
   include <- match.arg(include)
   resolution_x <- get_resolution(tf_arg(x))
   # if user supplied domain limit(s), remove
-  if (splits[1] == tf_domain(x)[1]) {
+  if (length(splits) && splits[1] == tf_domain(x)[1]) {
     splits <- splits[-1]
   }
-  if (splits[length(splits)] == tf_domain(x)[2]) {
+  if (length(splits) && splits[length(splits)] == tf_domain(x)[2]) {
     splits <- splits[-length(splits)]
+  }
+  if (length(splits) == 0) {
+    return(list(x))
   }
 
   start <- c(tf_domain(x)[1], splits)
   end <- c(splits, tf_domain(x)[2])
   if (include == "left") {
-    end[1:(length(end) - 1)] <- head(end, -1) - resolution_x
+    end[seq_len(length(end) - 1)] <- head(end, -1) - resolution_x
   }
   if (include == "right") {
     start[-1] <- start[-1] + resolution_x

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -239,7 +239,7 @@ fivenum.tf <- function(x, na.rm = FALSE, depth = "MHI", ...) {
 Summary.tf <- function(...) {
   not_defined <- switch(.Generic, all = , any = TRUE, FALSE)
   if (not_defined) {
-    cli::cli_abort("{.Generic} not defined for {.cls tf} objects.")
+    cli::cli_abort("{(.Generic)} not defined for {.cls tf} objects.")
   }
   # min, max, range have dedicated methods that accept a depth argument
   if (.Generic %in% c("min", "max", "range")) {

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -42,7 +42,7 @@ summarize_tf <- function(..., op = NULL, eval = FALSE, verbose = TRUE) {
     }
     return(unname(ret))
   }
-  ret <- do.call(
+  do.call(
     tfb,
     c(args, penalized = FALSE, verbose = FALSE, attr(funs, "basis_args"))
   ) |>

--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -1,8 +1,32 @@
-test_that("plot.tf with points = TRUE does not warn (#248)", {
+test_that("plot.tf(points = TRUE) passes col (not 'ol') to matlines (#248)", {
   x <- tf_rgp(3)
   pdf(NULL)
   on.exit(dev.off(), add = TRUE)
-  expect_no_warning(plot(x, points = TRUE))
+
+  # Capture the call matlines() receives. Use an env in globalenv() so the
+  # tracer (which runs in the traced function's frame) can reach it.
+  capture_env <- new.env(parent = emptyenv())
+  assign(".tf_matlines_call", capture_env, envir = globalenv())
+  on.exit(rm(".tf_matlines_call", envir = globalenv()), add = TRUE)
+
+  trace(
+    graphics::matlines,
+    tracer = quote(
+      assign(
+        "call",
+        match.call(),
+        envir = get(".tf_matlines_call", envir = globalenv())
+      )
+    ),
+    print = FALSE
+  )
+  on.exit(suppressMessages(untrace(graphics::matlines)), add = TRUE)
+
+  plot(x, points = TRUE)
+
+  arg_names <- names(as.list(capture_env$call)[-1])
+  expect_true("col" %in% arg_names)
+  expect_false("ol" %in% arg_names)
 })
 
 test_that("plot.tf smoke test for basic types", {

--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -1,0 +1,16 @@
+test_that("plot.tf with points = TRUE does not warn (#248)", {
+  x <- tf_rgp(3)
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
+  expect_no_warning(plot(x, points = TRUE))
+})
+
+test_that("plot.tf smoke test for basic types", {
+  x <- tf_rgp(3)
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
+  expect_no_error(plot(x))
+  expect_no_error(plot(x, points = TRUE))
+  expect_no_error(plot(x, type = "lasagna"))
+  expect_no_error(lines(x))
+})

--- a/tests/testthat/test-split-combine.R
+++ b/tests/testthat/test-split-combine.R
@@ -28,6 +28,19 @@ test_that("tf_split works as expected", {
   expect_identical(map(tfs_r, tf_domain), list(c(0, 0.3), c(0.301, 1)))
 })
 
+test_that("tf_split handles splits at domain boundaries (#251)", {
+  x <- tf_rgp(3)
+  # splits only at domain boundaries -> no split
+  expect_identical(tf_split(x, splits = 0), list(x))
+  expect_identical(tf_split(x, splits = 1), list(x))
+  expect_identical(tf_split(x, splits = c(0, 1)), list(x))
+  # include = "left" with a single split should not error
+  expect_no_error(tf_split(x, splits = 0.5, include = "left"))
+  # single-split inputs with boundary-equal splits should not error
+  expect_no_error(tf_split(x, splits = 0, include = "left"))
+  expect_no_error(tf_split(x, splits = 1, include = "left"))
+})
+
 
 test_that("tf_combine works as expected", {
   x <- tf_rgp(3)

--- a/tests/testthat/test-summarize.R
+++ b/tests/testthat/test-summarize.R
@@ -243,3 +243,9 @@ test_that("cum* functions work for tfb objects", {
   #   )
   # }
 })
+
+test_that("sd/var return visibly for tfb (#250)", {
+  xb <- suppressWarnings(tfb(tf_rgp(5), verbose = FALSE))
+  expect_true(withVisible(sd(xb))$visible)
+  expect_true(withVisible(var(xb))$visible)
+})

--- a/tests/testthat/test-summarize.R
+++ b/tests/testthat/test-summarize.R
@@ -249,3 +249,11 @@ test_that("sd/var return visibly for tfb (#250)", {
   expect_true(withVisible(sd(xb))$visible)
   expect_true(withVisible(var(xb))$visible)
 })
+
+test_that("Summary.tf error messages do not crash cli (#247)", {
+  x <- tf_rgp(3)
+  expect_error(all(x), "not defined")
+  expect_error(any(x), "not defined")
+  # prod is a Summary-group generic but should not land in the error branch
+  expect_no_error(prod(x))
+})


### PR DESCRIPTION
Four small isolated bugs.

- Closes #247 — `all(x)`/`any(x)` error path itself crashed because `cli::cli_abort("{.Generic} ...")` was parsed by cli as a malformed inline style. Use `{(.Generic)}`.
- Closes #248 — `plot.tf(points = TRUE)` had a typo `ol = rgb(...)` for `col = rgb(...)`. New `test-graphics.R` traces `matlines()` to actually catch the bug (verified the test fails on the buggy code and passes on the fix).
- Closes #250 — `sd(xb)`/`var(xb)` returned invisibly for `tfb` (vestigial `ret <-`).
- Closes #251 — `tf_split` crashed for splits at domain boundaries (`if (logical(0))`) and for single-split inputs (`1:0`). Guarded.

`devtools::test()` clean.

Background: part of the [June-2026 ground-up review](https://github.com/tidyfun/tf/blob/claude/ground-up-review/attic/design/ground-up-review-2026-06.md).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_