### PR TITLE
Defend tfb_mfpc joint-fit invariants from silent destruction (#257)

### DIFF
--- a/R/accessors-mv.R
+++ b/R/accessors-mv.R
@@ -117,11 +117,21 @@ check_component_index <- function(which, comps, arg = "which") {
   }
   # Replacing a component invalidates the joint MFPC eigenbasis (the shared
   # scores no longer correspond to the new component), so warn and demote
-  # before the value is swapped in.
+  # before the value is swapped in. `tfb_mfpc_demote()` rebuilds the retained
+  # components as standalone full-rank `tfb_fpc` -- merely dropping the `mfpc`
+  # attribute would leave them with the abort-stub `scoring_function`, breaking
+  # subsequent arithmetic / `tf_rebase()`. The same applies to a `value` taken
+  # from this very fit (e.g. `mf2$x <- mf$x`), which is rebuilt as well.
   if (is_tfb_mfpc(f)) {
     warn_mfpc_demotion(
       "Replacing a component invalidates the joint MFPC eigenbasis."
     )
+    value <- mfpc_demote_component_value(
+      value,
+      tf_components(f),
+      attr(f, "mfpc")$uni
+    )
+    f <- tfb_mfpc_demote(f)
   }
   comps <- tf_components(f)
   if (is.character(which)) {
@@ -140,8 +150,8 @@ check_component_index <- function(which, comps, arg = "which") {
     comps[[which]] <- value
   }
   # new_tf_mv() validates that `value` is the same kind (tfd/tfb) as the other
-  # components and that its domain is compatible. The joint MFPC spec is
-  # intentionally not forwarded -- see warning above.
+  # components and that its domain is compatible. The joint MFPC spec was
+  # dropped by tfb_mfpc_demote() above and is intentionally not forwarded.
   new_tf_mv(comps, domain = tf_domain(f))
 }
 

--- a/R/accessors-mv.R
+++ b/R/accessors-mv.R
@@ -115,6 +115,14 @@ check_component_index <- function(which, comps, arg = "which") {
       "Replacement component has length {vec_size(value)}, expected {vec_size(f)}."
     )
   }
+  # Replacing a component invalidates the joint MFPC eigenbasis (the shared
+  # scores no longer correspond to the new component), so warn and demote
+  # before the value is swapped in.
+  if (is_tfb_mfpc(f)) {
+    warn_mfpc_demotion(
+      "Replacing a component invalidates the joint MFPC eigenbasis."
+    )
+  }
   comps <- tf_components(f)
   if (is.character(which)) {
     # validate the scalar name *before* the vectorized `%in%` below, which
@@ -132,7 +140,8 @@ check_component_index <- function(which, comps, arg = "which") {
     comps[[which]] <- value
   }
   # new_tf_mv() validates that `value` is the same kind (tfd/tfb) as the other
-  # components and that its domain is compatible.
+  # components and that its domain is compatible. The joint MFPC spec is
+  # intentionally not forwarded -- see warning above.
   new_tf_mv(comps, domain = tf_domain(f))
 }
 

--- a/R/brackets-mv.R
+++ b/R/brackets-mv.R
@@ -169,5 +169,8 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
     comp
   })
   names(comps) <- attr(x, "comp_names")
-  new_tf_mv(comps, domain = tf_domain(x))
+  # Forward the joint MFPC spec, if any: setting curve names is a non-mutating
+  # rename and must not silently demote a `tfb_mfpc`. (`vec_c()` runs `names<-`
+  # post-restore, which would otherwise strip the spec set by `tf_mv_ptype2`.)
+  new_tf_mv(comps, domain = tf_domain(x), mfpc = attr(x, "mfpc"))
 }

--- a/R/ops-mv.R
+++ b/R/ops-mv.R
@@ -1,5 +1,19 @@
 # Arithmetic, math, summaries (all component-wise) -----------------------------
 
+# Demote a `tfb_mfpc` operand before Math/Ops touch its `tfb_fpc` components.
+# Scoring a single MFPC component is ill-defined (see `mfpc_component_scoring`),
+# so any arithmetic / Math.Generic must drop the joint spec first. We warn once
+# per operation and continue along the standard component-wise path.
+mfpc_demote_for_op <- function(x, op) {
+  if (is_tfb_mfpc(x)) {
+    warn_mfpc_demotion(paste0(
+      "Operation {.code ", op, "} on a {.cls tfb_mfpc} forces per-component arithmetic."
+    ))
+    return(tfb_mfpc_demote(x))
+  }
+  x
+}
+
 #' @export
 #' @method vec_arith tf_mv
 vec_arith.tf_mv <- function(op, x, y, ...) {
@@ -15,30 +29,36 @@ vec_arith.tf_mv.default <- function(op, x, y, ...) {
 #' @export
 #' @method vec_arith.tf_mv tf_mv
 vec_arith.tf_mv.tf_mv <- function(op, x, y, ...) {
+  x <- mfpc_demote_for_op(x, op)
+  y <- mfpc_demote_for_op(y, op)
   map2_components(x, y, \(a, b) vec_arith(op, a, b))
 }
 
 #' @export
 #' @method vec_arith.tf_mv numeric
 vec_arith.tf_mv.numeric <- function(op, x, y, ...) {
+  x <- mfpc_demote_for_op(x, op)
   map_components(x, \(a) vec_arith(op, a, y))
 }
 
 #' @export
 #' @method vec_arith.numeric tf_mv
 vec_arith.numeric.tf_mv <- function(op, x, y, ...) {
+  y <- mfpc_demote_for_op(y, op)
   map_components(y, \(b) vec_arith(op, x, b))
 }
 
 #' @export
 #' @method vec_arith.tf_mv MISSING
 vec_arith.tf_mv.MISSING <- function(op, x, y, ...) {
+  x <- mfpc_demote_for_op(x, op)
   map_components(x, \(a) vec_arith(op, a, MISSING()))
 }
 
 #' @export
 Math.tf_mv <- function(x, ...) {
   generic <- .Generic
+  x <- mfpc_demote_for_op(x, generic)
   map_components(x, \(a) do.call(generic, list(a, ...)))
 }
 

--- a/R/ops-mv.R
+++ b/R/ops-mv.R
@@ -4,11 +4,13 @@
 # Scoring a single MFPC component is ill-defined (see `mfpc_component_scoring`),
 # so any arithmetic / Math.Generic must drop the joint spec first. We warn once
 # per operation and continue along the standard component-wise path.
-mfpc_demote_for_op <- function(x, op) {
+mfpc_demote_for_op <- function(x, op, warn = TRUE) {
   if (is_tfb_mfpc(x)) {
-    warn_mfpc_demotion(paste0(
-      "Operation {.code ", op, "} on a {.cls tfb_mfpc} forces per-component arithmetic."
-    ))
+    if (warn) {
+      warn_mfpc_demotion(paste0(
+        "Operation {.code ", op, "} on a {.cls tfb_mfpc} forces per-component arithmetic."
+      ))
+    }
     return(tfb_mfpc_demote(x))
   }
   x
@@ -29,8 +31,11 @@ vec_arith.tf_mv.default <- function(op, x, y, ...) {
 #' @export
 #' @method vec_arith.tf_mv tf_mv
 vec_arith.tf_mv.tf_mv <- function(op, x, y, ...) {
+  # if both operands are tfb_mfpc, warn only once for the single user-facing
+  # operation: the warning for `y` is suppressed when `x` already triggered it.
+  x_warns <- is_tfb_mfpc(x)
   x <- mfpc_demote_for_op(x, op)
-  y <- mfpc_demote_for_op(y, op)
+  y <- mfpc_demote_for_op(y, op, warn = !x_warns)
   map2_components(x, y, \(a, b) vec_arith(op, a, b))
 }
 

--- a/R/tfb-mfpc.R
+++ b/R/tfb-mfpc.R
@@ -383,6 +383,38 @@ mfpc_component_scoring <- function(...) {
   ))
 }
 
+# Demote a `tfb_mfpc` to a plain `tfb_mv` by stripping the joint spec. Used by
+# Math/Ops and `$<-` interceptors that warn the user the joint MFPC
+# representation is being dropped before continuing along the standard
+# `tfb_mv` path. The per-component `scoring_function`s on the underlying
+# `tfb_fpc` objects are also swapped from the abort-stub
+# (`mfpc_component_scoring`) to the standard univariate scorer
+# (`.fpc_wsvd_scores`) so that downstream `tf_rebase()` (called by Math/Ops on
+# `tfb_fpc`) can re-fit scores per component without exploding.
+tfb_mfpc_demote <- function(x) {
+  attr(x, "mfpc") <- NULL
+  comps <- attr(x, "components")
+  comps <- lapply(comps, function(comp) {
+    if (identical(attr(comp, "scoring_function"), mfpc_component_scoring)) {
+      attr(comp, "scoring_function") <- .fpc_wsvd_scores
+    }
+    comp
+  })
+  attr(x, "components") <- comps
+  x
+}
+
+# Internal warning shown when an operation forces a `tfb_mfpc` back to a plain
+# per-component `tfb_fpc` (`tfb_mv`) representation. Centralised so the message
+# stays consistent across Math/Ops, `$<-` and `vec_c()`.
+warn_mfpc_demotion <- function(reason) {
+  cli::cli_warn(c(
+    "Demoting to per-component {.cls tfb_fpc} representation; the joint MFPC spec is dropped.",
+    i = reason,
+    i = "Re-score with {.fn tf_rebase} for joint MFPC arithmetic."
+  ))
+}
+
 # Joint re-scoring of new data onto a fitted MFPC basis ------------------------
 
 # `newdata`: a tf_mv (tfd_mv/tfb_mv) compatible with `mfpc_obj`.

--- a/R/tfb-mfpc.R
+++ b/R/tfb-mfpc.R
@@ -450,13 +450,17 @@ new_tfb_fpc_demoted <- function(component, uni) {
 
 # Internal warning shown when an operation forces a `tfb_mfpc` back to a plain
 # per-component `tfb_fpc` (`tfb_mv`) representation. Centralised so the message
-# stays consistent across Math/Ops, `$<-` and `vec_c()`.
+# stays consistent across Math/Ops, `$<-` and `vec_c()`. Uses class
+# `tf_mfpc_demotion` so callers can intercept via `withCallingHandlers()`.
 warn_mfpc_demotion <- function(reason) {
-  cli::cli_warn(c(
-    "Demoting to per-component {.cls tfb_fpc} representation; the joint MFPC spec is dropped.",
-    i = reason,
-    i = "Re-score with {.fn tf_rebase} for joint MFPC arithmetic."
-  ))
+  cli::cli_warn(
+    c(
+      "Demoting to per-component {.cls tfb_fpc} representation; the joint MFPC spec is dropped.",
+      i = reason,
+      i = "Re-score with {.fn tf_rebase} for joint MFPC arithmetic."
+    ),
+    class = "tf_mfpc_demotion"
+  )
 }
 
 # Joint re-scoring of new data onto a fitted MFPC basis ------------------------

--- a/R/tfb-mfpc.R
+++ b/R/tfb-mfpc.R
@@ -448,6 +448,29 @@ new_tfb_fpc_demoted <- function(component, uni) {
   )
 }
 
+# Rebuild a single shared-score MFPC component that is assigned as a
+# standalone vector (e.g. the `value` in `mf2$x <- mf$x`), so it does not
+# retain the abort-stub `scoring_function`. The matching univariate FPCA fit
+# is identified by the component's joint basis matrix among the parent fit's
+# original components `comps`; components from a foreign fit (no match) are
+# returned unchanged.
+mfpc_demote_component_value <- function(value, comps, uni) {
+  if (
+    !is_tfb_fpc(value) ||
+      !identical(attr(value, "scoring_function"), mfpc_component_scoring)
+  ) {
+    return(value)
+  }
+  match_k <- which(map_lgl(
+    comps,
+    \(co) identical(attr(co, "basis_matrix"), attr(value, "basis_matrix"))
+  ))
+  if (!length(match_k)) {
+    return(value)
+  }
+  new_tfb_fpc_demoted(value, uni[[match_k[1]]])
+}
+
 # Internal warning shown when an operation forces a `tfb_mfpc` back to a plain
 # per-component `tfb_fpc` (`tfb_mv`) representation. Centralised so the message
 # stays consistent across Math/Ops, `$<-` and `vec_c()`. Uses class

--- a/R/tfb-mfpc.R
+++ b/R/tfb-mfpc.R
@@ -223,7 +223,8 @@ mfpc_fit <- function(
         efunctions = s$efunctions,
         mu = s$mu,
         arg = s$arg,
-        scoring_function = s$scoring_function
+        scoring_function = s$scoring_function,
+        evalues = s$evalues
       )
     })
   )
@@ -386,22 +387,65 @@ mfpc_component_scoring <- function(...) {
 # Demote a `tfb_mfpc` to a plain `tfb_mv` by stripping the joint spec. Used by
 # Math/Ops and `$<-` interceptors that warn the user the joint MFPC
 # representation is being dropped before continuing along the standard
-# `tfb_mv` path. The per-component `scoring_function`s on the underlying
-# `tfb_fpc` objects are also swapped from the abort-stub
-# (`mfpc_component_scoring`) to the standard univariate scorer
-# (`.fpc_wsvd_scores`) so that downstream `tf_rebase()` (called by Math/Ops on
-# `tfb_fpc`) can re-fit scores per component without exploding.
+# `tfb_mv` path. Each shared-score component carries a rank-deficient
+# multivariate eigenfunction basis (`Psi_j` lives in an M-dim space but only
+# spans `rank <= ncol(phi_j)` directions in the per-component grid), so simply
+# swapping the abort-stub `scoring_function` for `.fpc_wsvd_scores` is not
+# enough: downstream `tf_rebase()` would fit data via `qr.coef()` on a
+# rank-deficient `Psi_j` and return `NA` scores. Instead, rebuild each
+# component as a fresh `tfb_fpc` on the *univariate* basis (the full-rank
+# orthonormal `phi^(j)` from the univariate FPCA stored in `mfpc$uni`), with
+# the component's own univariate `scoring_function` (or `.fpc_wsvd_scores` as
+# fallback), so Math/Ops dispatched on `tfb_fpc` can re-fit scores without
+# exploding.
 tfb_mfpc_demote <- function(x) {
+  mfpc <- attr(x, "mfpc")
   attr(x, "mfpc") <- NULL
   comps <- attr(x, "components")
-  comps <- lapply(comps, function(comp) {
-    if (identical(attr(comp, "scoring_function"), mfpc_component_scoring)) {
-      attr(comp, "scoring_function") <- .fpc_wsvd_scores
-    }
-    comp
-  })
-  attr(x, "components") <- comps
+  if (is.null(mfpc) || is.null(mfpc$uni)) {
+    # nothing to rebuild against; leave components as-is.
+    return(x)
+  }
+  new_comps <- map2(comps, mfpc$uni, new_tfb_fpc_demoted)
+  names(new_comps) <- names(comps)
+  attr(x, "components") <- new_comps
   x
+}
+
+# Rebuild a single shared-score MFPC component as a plain, full-rank `tfb_fpc`
+# on the stored univariate eigenfunctions `phi^(j)`. The component's
+# evaluations are reconstructed from the joint basis (`mu_j + Psi_j s^T`) and
+# then re-scored onto `phi^(j)` using the univariate `scoring_function`.
+new_tfb_fpc_demoted <- function(component, uni) {
+  arg <- uni$arg
+  mu_j <- uni$mu
+  phi_j <- uni$efunctions
+  scoring_function <- uni$scoring_function %||% .fpc_wsvd_scores
+  # reconstruct evaluations on the univariate grid from the joint basis.
+  joint_bm <- attr(component, "basis_matrix") # n_arg x (1 + M)
+  coefs_old <- do.call(rbind, unclass(component)) # n x (1 + M)
+  data_matrix <- coefs_old %*% t(joint_bm) # n x n_arg
+  quad_w <- mfpc_quad_weights(arg)
+  scores <- as.matrix(scoring_function(data_matrix, phi_j, mu_j, quad_w))
+  basis_matrix <- unname(cbind(mu_j, phi_j))
+  domain <- attr(component, "domain")
+  fpc_basis <- suppressMessages(tfd(t(basis_matrix), arg = arg, domain = domain))
+  fpc_constructor <- fpc_wrapper(fpc_basis)
+  coefs <- cbind(1, scores)
+  coef_list <- split(coefs, row(coefs))
+  names(coef_list) <- names(component)
+  basis_label <- paste0(ncol(phi_j), " FPCs")
+  new_vctr(
+    coef_list,
+    domain = domain,
+    basis = fpc_constructor,
+    basis_label = basis_label,
+    basis_matrix = basis_matrix,
+    arg = arg,
+    score_variance = uni$evalues %||% rep(NA_real_, ncol(phi_j)),
+    scoring_function = scoring_function,
+    class = c("tfb_fpc", "tfb", "tf")
+  )
 }
 
 # Internal warning shown when an operation forces a `tfb_mfpc` back to a plain

--- a/R/vctrs-mv.R
+++ b/R/vctrs-mv.R
@@ -25,10 +25,10 @@ vec_restore.tf_mv <- function(x, to, ...) {
   components <- as.list(x)
   # An MFPC fit carries a curve-independent joint spec. Slicing reuses the
   # original object as `to`, so the spec (and the ability to re-score) is
-  # preserved. Concatenation (`vec_c`/`c`) uses a bare prototype as `to` (built
-  # by `tf_mv_ptype2()` without a spec), so it intentionally drops the spec --
-  # stamping one fit's eigenbasis onto a concatenation of possibly different
-  # fits would be wrong.
+  # preserved. Concatenation (`vec_c`/`c`) builds `to` via `tf_mv_ptype2()`,
+  # which forwards an `identical()`-matching spec (same fit, e.g. `c(mf[1:4],
+  # mf[5:8])`) and otherwise demotes with a warning -- so reading the spec off
+  # `to` here is correct for both paths.
   mfpc <- attr(to, "mfpc")
   if (!length(components)) {
     return(new_tf_mv(
@@ -69,7 +69,31 @@ tf_mv_ptype2 <- function(x, y, ...) {
   check_compatible_mv(x, y)
   comps <- map2(tf_components(x), tf_components(y), \(a, b) vec_ptype2(a, b))
   names(comps) <- attr(x, "comp_names")
-  new_tf_mv(comps)
+  # Carry the joint MFPC spec through `vec_c()` when *all* inputs are the same
+  # fit, i.e. carry an `identical()` `mfpc` attribute. `vec_ptype2()` is called
+  # pairwise so an identical match here -- combined with the matching pairwise
+  # checks performed by `vec_c()` -- implies all inputs share the spec.
+  # The result of `vec_ptype2` becomes `to` in `vec_restore.tf_mv`, where the
+  # spec is then re-stamped onto the concatenation. When specs differ (or one
+  # side is a plain `tfb_mv` / `tfd_mv` with no spec) we warn and demote -- the
+  # downgrade matters because a `dplyr::bind_rows` round-trip otherwise
+  # silently strips the spec.
+  mfpc_x <- attr(x, "mfpc")
+  mfpc_y <- attr(y, "mfpc")
+  proto <- new_tf_mv(comps)
+  same_spec <- identical(mfpc_x, mfpc_y) && !is.null(mfpc_x)
+  if (same_spec && is_tfb_mv(proto)) {
+    attr(proto, "mfpc") <- mfpc_x
+  } else if (!is.null(mfpc_x) || !is.null(mfpc_y)) {
+    # warn only when at least one side actually had a spec to lose. The proto
+    # may have demoted further to `tfd_mv` (when component bases differ) -- the
+    # extra demote_warning is still useful: the per-component
+    # `vec_ptype2.tfb_fpc.tfb_fpc` cast-warning does not mention MFPC.
+    warn_mfpc_demotion(
+      "Combining MFPC fits with different (or missing) joint specs."
+    )
+  }
+  proto
 }
 
 tf_mv_cast <- function(x, to, ...) {

--- a/tests/testthat/test-mfpc.R
+++ b/tests/testthat/test-mfpc.R
@@ -198,6 +198,34 @@ test_that("post-demotion tfb_mv stays functional", {
   expect_no_error(tf_evaluate(mf2))
 })
 
+test_that("demoted tfb_mfpc supports chained Math/Ops", {
+  set.seed(1)
+  mf <- tfb_mfpc(tfd_mv(list(x = tf_rgp(20), y = tf_rgp(20))), pve = 0.95) |>
+    suppressWarnings()
+  expect_no_error(out1 <- suppressWarnings((mf + 1) - 1))
+  expect_no_error(out2 <- suppressWarnings(log(mf + 2)))
+  expect_no_error(out3 <- suppressWarnings(-mf))
+  expect_no_error(out4 <- suppressWarnings(mf * 2 / 2))
+  # reconstructed values are sane (finite) after a round-trip through ops
+  expect_true(all(is.finite(unlist(tf_evaluations(out1)))))
+})
+
+test_that("demotion warning has class 'tf_mfpc_demotion'", {
+  set.seed(8)
+  mf <- tfb_mfpc(tfd_mv(list(x = tf_rgp(10), y = tf_rgp(10))), pve = 0.95) |>
+    suppressWarnings()
+  classes <- character()
+  withCallingHandlers(
+    mf + 1,
+    tf_mfpc_demotion = function(w) {
+      classes <<- c(classes, class(w))
+      invokeRestart("muffleWarning")
+    },
+    warning = function(w) invokeRestart("muffleWarning")
+  )
+  expect_true("tf_mfpc_demotion" %in% classes)
+})
+
 test_that("c() of MFPC fits with different specs demotes with a warning", {
   set.seed(1)
   mf1 <- tfb_mfpc(tfd_mv(list(x = tf_rgp(10), y = tf_rgp(10))), pve = 0.95)

--- a/tests/testthat/test-mfpc.R
+++ b/tests/testthat/test-mfpc.R
@@ -196,6 +196,12 @@ test_that("post-demotion tfb_mv stays functional", {
   # evaluating the demoted object must not explode in the per-component
   # scoring stub
   expect_no_error(tf_evaluate(mf2))
+  # arithmetic re-scores via the components' scoring_function, so it must not
+  # hit the abort stub either -- this exercises the rebuilt standalone bases,
+  # including the assigned `value` (which came from the same MFPC fit).
+  expect_no_error(suppressWarnings(out <- mf2 + 1))
+  expect_true(all(is.finite(unlist(tf_evaluations(out)))))
+  expect_no_error(suppressWarnings(tf_rebase(mf2, mf2)))
 })
 
 test_that("demoted tfb_mfpc supports chained Math/Ops", {

--- a/tests/testthat/test-mfpc.R
+++ b/tests/testthat/test-mfpc.R
@@ -143,15 +143,69 @@ test_that("scoring a single MFPC component directly is an error", {
   )
 })
 
-test_that("slicing preserves the MFPC spec; concatenation drops it", {
+test_that("slicing and same-fit concatenation preserve the MFPC spec", {
   set.seed(11)
   g <- tfd_mv(list(x = tf_rgp(12), y = tf_rgp(12)))
   m <- tfb_mfpc(g, npc = 3)
   # subsetting keeps the curve-independent eigenbasis -> still re-scorable
   expect_true(is_tfb_mfpc(m[1:5]))
   expect_equal(dim(tf_mfpc_scores(m[1:5])), c(5L, 3L))
-  # concatenation uses a bare prototype -> spec intentionally dropped
-  expect_false(is_tfb_mfpc(c(m[1:6], m[7:12])))
+  # concatenation of slices of the *same* fit keeps the spec
+  expect_true(is_tfb_mfpc(c(m[1:6], m[7:12])))
+  expect_true(is_tfb_mfpc(c(m, m)))
+})
+
+# Capture warning messages from an expression without aborting on them.
+collect_warnings <- function(expr) {
+  ws <- character()
+  val <- withCallingHandlers(
+    expr,
+    warning = function(w) {
+      ws <<- c(ws, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  list(value = val, warnings = ws)
+}
+
+test_that("tfb_mfpc protects its joint spec", {
+  set.seed(1)
+  mf <- tfb_mfpc(tfd_mv(list(x = tf_rgp(20), y = tf_rgp(20))), pve = 0.95)
+  # 1. Arithmetic demotes with a clear warning
+  cap <- collect_warnings(mf + 1)
+  expect_true(any(grepl("demot|mfpc|MFPC|joint", cap$warnings)))
+  expect_false(is_tfb_mfpc(cap$value))
+  # 2. $<- demotes with a clear warning
+  cap <- collect_warnings({
+    mf2 <- mf
+    mf2$x <- mf$x
+    mf2
+  })
+  expect_true(any(grepl("demot|mfpc|MFPC|joint", cap$warnings)))
+  expect_false(is_tfb_mfpc(cap$value))
+  # 3. c() of slices of the same fit preserves the spec
+  expect_true(is_tfb_mfpc(c(mf[1:4], mf[5:8])))
+})
+
+test_that("post-demotion tfb_mv stays functional", {
+  set.seed(42)
+  mf <- tfb_mfpc(tfd_mv(list(x = tf_rgp(10), y = tf_rgp(10))), pve = 0.95)
+  mf2 <- mf
+  suppressWarnings(mf2$x <- mf$x)
+  expect_false(is_tfb_mfpc(mf2))
+  # evaluating the demoted object must not explode in the per-component
+  # scoring stub
+  expect_no_error(tf_evaluate(mf2))
+})
+
+test_that("c() of MFPC fits with different specs demotes with a warning", {
+  set.seed(1)
+  mf1 <- tfb_mfpc(tfd_mv(list(x = tf_rgp(10), y = tf_rgp(10))), pve = 0.95)
+  set.seed(2)
+  mf2 <- tfb_mfpc(tfd_mv(list(x = tf_rgp(10), y = tf_rgp(10))), pve = 0.95)
+  cap <- collect_warnings(c(mf1, mf2))
+  expect_true(any(grepl("demot|mfpc|MFPC|joint", cap$warnings)))
+  expect_false(is_tfb_mfpc(cap$value))
 })
 
 test_that("mixing a tfd_mv with an MFPC tfb_mv demotes (no spec carried)", {

--- a/tests/testthat/test-mfpc.R
+++ b/tests/testthat/test-mfpc.R
@@ -204,6 +204,22 @@ test_that("post-demotion tfb_mv stays functional", {
   expect_no_error(suppressWarnings(tf_rebase(mf2, mf2)))
 })
 
+test_that("both-mfpc arithmetic warns about demotion exactly once", {
+  set.seed(21)
+  mf <- tfb_mfpc(tfd_mv(list(x = tf_rgp(10), y = tf_rgp(10))), pve = 0.95) |>
+    suppressWarnings()
+  n_demotion_warnings <- 0L
+  withCallingHandlers(
+    mf + mf,
+    tf_mfpc_demotion = function(w) {
+      n_demotion_warnings <<- n_demotion_warnings + 1L
+      invokeRestart("muffleWarning")
+    },
+    warning = function(w) invokeRestart("muffleWarning")
+  )
+  expect_identical(n_demotion_warnings, 1L)
+})
+
 test_that("demoted tfb_mfpc supports chained Math/Ops", {
   set.seed(1)
   mf <- tfb_mfpc(tfd_mv(list(x = tf_rgp(20), y = tf_rgp(20))), pve = 0.95) |>


### PR DESCRIPTION
Closes #257.

Three integrity gaps in `tfb_mfpc` allowed silent destruction of the joint-fit spec by routine operations:

- **Math/Ops**: `mf + 1` aborted with a baffling internal scoring error. Now intercepted: emit a classed `tf_mfpc_demotion` warning, then demote to per-component `tfb_fpc` and continue with the standard path. `Math.tf_mv` and every `vec_arith.tf_mv.*` route through `mfpc_demote_for_op()`.

- **Component replacement**: `mf$x <- some_other_tfb` silently dropped the joint spec. `tf_component<-` now warns (`tf_mfpc_demotion`) and demotes before assignment.

- **Concatenation of slices of the same fit**: `c(mf[1:4], mf[5:8])` dropped the spec. `tf_mv_ptype2` now keeps the spec when `identical(attr(x, "mfpc"), attr(y, "mfpc"))` and both are non-null. Different fits demote with a warning. Also fixes a load-bearing leak in `names<-.tf_mv` which was stripping `mfpc` after `vec_restore` (because `vec_c` runs `vec_set_names` post-restore).

### Demotion correctness (initial implementation had a bug)

Initial attempt swapped the per-component `scoring_function` from `mfpc_component_scoring` to `.fpc_wsvd_scores`, but the multivariate eigenfunctions `Psi_j` are rank-deficient on the per-component grid (rank ≤ `ncol(phi_j)` but `ncol(Psi_j) = M`). `.fpc_wsvd_scores` then ran `qr.coef()` on rank-deficient `Psi_j` and produced NA coefficients; the first Op silently yielded all-NA, the second tripped on the empty result. Final fix: on demotion, rebuild each component as a fresh full-rank `tfb_fpc` on the *univariate* basis stored in `attr(x, "mfpc")$uni`, re-scoring onto `phi^(j)` using the component's own univariate `scoring_function` (per-component, falling back to `.fpc_wsvd_scores` only if missing). Demotion is data-preserving (`as.tfd_mv()` matches pre/post to floating point).

### Tests

- `c(mf, mf)`, `c(mf[1:4], mf[5:8])` preserve `is_tfb_mfpc()`
- `c(mf1, mf2)` from different fits demotes with `tf_mfpc_demotion` warning
- `mf2 <- mf; mf2$x <- mf$x` demotes; post-demotion `tf_evaluate(mf2)` works
- **Chained Math/Ops** on demoted `tfb_mfpc`: `(mf+1)-1`, `log(mf+2)`, `-mf`, `mf * 2 / 2` all succeed with finite values

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_