### PR TITLE
NEWS + README for vector-valued FD; fdasrvf version floor (#258, #259)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
     covr,
     dplyr,
     fda,
-    fdasrvf,
+    fdasrvf (>= 2.4.0),
     pillar,
     refund,
     testthat (>= 3.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,15 +14,37 @@
   observed arg range (i.e., the range of its `tf_arg()` values). Pass explicit
   `lower` / `upper` (or an extrapolating evaluator) to override (#253).
 
-## New features
+## Vector-valued functional data
 
+This release introduces first-class support for vector-valued (multivariate)
+functional data -- functions whose codomain is `R^d` -- alongside the existing
+univariate `tfd`/`tfb` classes.
+
+* `tfd_mv()` and `tfb_mv()`: new `vctrs`-based S3 classes for vector-valued
+  functional data, holding several component functions per observation on a
+  shared domain. Constructors accept named lists of `tfd`/`tfb` vectors or
+  list-columns of matrices.
 * `tfb_mfpc()` implements multivariate functional principal component analysis
-  (Happ & Greven, 2018) for vector-valued (`tf_mv`) data: a single set of scalar
-  scores per curve shared across all components, with vector-valued
-  eigenfunctions. Component weighting is configurable (`"inverse_variance"`
-  default, `"snr"`, `"equal"`, or user-supplied). New data can be projected onto
-  a fitted basis via `tf_rebase()` / `vec_cast()`. Accessors `tf_mfpc_scores()`,
+  (Happ & Greven, 2018) for `tf_mv` data: a single set of scalar scores per
+  curve shared across all components, with vector-valued eigenfunctions.
+  Component weighting is configurable (`"inverse_variance"` default, `"snr"`,
+  `"equal"`, or user-supplied). New data can be projected onto a fitted basis
+  via `tf_rebase()` / `vec_cast()`. Accessors `tf_mfpc_scores()`,
   `tf_mfpc_efunctions()` and the predicate `is_tfb_mfpc()`.
+* Multivariate registration: `tf_register()` gains `method = "srvf_mv"` for
+  jointly aligning the components of `tf_mv` curves via the multivariate SRVF
+  framework, and `tf_register_shape()` provides elastic shape registration
+  (rotation/translation/scale-invariant) via `fdasrvf`.
+* New geometry verbs for `tf_mv` (and where meaningful for univariate `tf`):
+  `tf_norm()`, `tf_inner()`, `tf_tangent()`, `tf_arclength()`.
+* `tf_mv_*` accessors, `tf_split()` / `tf_combine()` extensions and `[`/`[[`
+  methods for extracting, replacing and recombining components.
+
+### Contract change
+
+* `is_tf()` now returns `TRUE` for `tf_mv` as well as univariate `tfd`/`tfb`.
+  Code that branched on `is_tf()` to mean "univariate `tf`" should switch to
+  the new predicate `is_tf_1d()`.
 
 # tf 0.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,8 +37,9 @@ univariate `tfd`/`tfb` classes.
   (rotation/translation/scale-invariant) via `fdasrvf`.
 * New geometry verbs for `tf_mv` (and where meaningful for univariate `tf`):
   `tf_norm()`, `tf_inner()`, `tf_tangent()`, `tf_arclength()`.
-* `tf_mv_*` accessors, `tf_split()` / `tf_combine()` extensions and `[`/`[[`
-  methods for extracting, replacing and recombining components.
+* Component accessors (`tf_ncomp()`, `tf_components()`, `tf_component()`),
+  `tf_split()` / `tf_combine()` extensions and `[`/`[[` methods for extracting,
+  replacing and recombining components.
 
 ### Contract change
 

--- a/R/register-mv.R
+++ b/R/register-mv.R
@@ -230,7 +230,11 @@ tf_register_srvf_mv <- function(
   lambda = 0,
   ...
 ) {
-  rlang::check_installed("fdasrvf")
+  rlang::check_installed(
+    "fdasrvf",
+    version = "2.4.0",
+    reason = "for multivariate SRVF registration"
+  )
   dots <- list(...)
   srvf_mv_check_dots(dots)
   srvf_mv_validate_regular(x)
@@ -374,7 +378,11 @@ tf_register_shape <- function(
   store_x = TRUE
 ) {
   cl <- match.call()
-  rlang::check_installed("fdasrvf")
+  rlang::check_installed(
+    "fdasrvf",
+    version = "2.4.0",
+    reason = "for multivariate SRVF shape registration"
+  )
   srvf_mv_validate_regular(x)
   if (!is.null(template)) {
     srvf_mv_validate_regular(template, arg = "template")

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 [![R-universe version](https://tidyfun.r-universe.dev/tf/badges/version)](https://tidyfun.r-universe.dev/tf)
 <!-- badges: end -->
 
-The **`tf`** package provides necessary infrastructure for [**`tidyfun`**](https://tidyfun.github.io/tidyfun/) with minimal dependencies -- `vctrs`/`rlang`/`cli`/`purrr` from the r-lib/tidyverse ecosystem, otherwise just `mgcv`, `zoo`, `mvtnorm`, `pracma`, `checkmate`.
+The **`tf`** package provides necessary infrastructure for [**`tidyfun`**](https://tidyfun.github.io/tidyfun/) with minimal dependencies -- `vctrs`/`rlang`/`cli`/`purrr` from the r-lib/tidyverse ecosystem, otherwise just `mgcv`, `zoo`, and `checkmate`.
 
 The goal of **`tidyfun`**, in turn, is to provide accessible and well-documented software that **makes functional data analysis in `R` easy** -- specifically data wrangling and exploratory analysis. 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 [![R-universe version](https://tidyfun.r-universe.dev/tf/badges/version)](https://tidyfun.r-universe.dev/tf)
 <!-- badges: end -->
 
-The **`tf`** package provides necessary infrastructure for [**`tidyfun`**](https://tidyfun.github.io/tidyfun/) with minimal dependencies -- specifically: no `tidyverse`-dependencies.  
+The **`tf`** package provides necessary infrastructure for [**`tidyfun`**](https://tidyfun.github.io/tidyfun/) with minimal dependencies -- `vctrs`/`rlang`/`cli`/`purrr` from the r-lib/tidyverse ecosystem, otherwise just `mgcv`, `zoo`, `mvtnorm`, `pracma`, `checkmate`.
 
 The goal of **`tidyfun`**, in turn, is to provide accessible and well-documented software that **makes functional data analysis in `R` easy** -- specifically data wrangling and exploratory analysis. 
 
@@ -82,7 +82,18 @@ are defined for the vector classes defined in **`tf`** ([more](https://tidyfun.g
 
 The `tf` objects are just glorified lists, so they work well as columns in data frames. That makes it a lot easier to keep your other data and functional measurements together in one object for preprocessing, exploratory analysis and description. At the same time, these objects actually behave like vectors of *functions* to some extent, i.e., they can be evaluated on any point in their domain, they can be integrated or differentiated, etc.
 
-[See here](https://tidyfun.github.io/tidyfun/articles/x01_tf_Vectors.html) for more information on the operations defined for `tf` vectors. 
+[See here](https://tidyfun.github.io/tidyfun/articles/x01_tf_Vectors.html) for more information on the operations defined for `tf` vectors.
+
+#### Vector-valued (multivariate) functional data
+
+`tf` also provides `tfd_mv()` and `tfb_mv()` for vector-valued functional data -- i.e., functions whose codomain is `R^d`, sharing a single domain across components. These behave like the univariate `tf` classes (subsetting, arithmetic, plotting), with component-wise accessors and the geometry verbs `tf_norm()`, `tf_inner()`, `tf_tangent()`, `tf_arclength()`:
+
+```{r, eval = FALSE}
+fm <- tfd_mv(list(x = tf_rgp(5), y = tf_rgp(5)))
+plot(fm, type = "facet")
+```
+
+Multivariate FPCA is available via `tfb_mfpc()` (Happ & Greven, 2018), and `tf_register()` supports joint multivariate alignment (`method = "srvf_mv"`) as well as elastic shape registration (`tf_register_shape()`). Note that `is_tf()` is `TRUE` for `tf_mv` as well; use the new `is_tf_1d()` to test specifically for univariate `tf`.
 
 #### Methods for converting existing data to `tf` and back
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ version](https://tidyfun.r-universe.dev/tf/badges/version)](https://tidyfun.r-un
 The **`tf`** package provides necessary infrastructure for
 [**`tidyfun`**](https://tidyfun.github.io/tidyfun/) with minimal
 dependencies – `vctrs`/`rlang`/`cli`/`purrr` from the r-lib/tidyverse
-ecosystem, otherwise just `mgcv`, `zoo`, `mvtnorm`, `pracma`,
-`checkmate`.
+ecosystem, otherwise just `mgcv`, `zoo`, and `checkmate`.
 
 The goal of **`tidyfun`**, in turn, is to provide accessible and
 well-documented software that **makes functional data analysis in `R`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ version](https://tidyfun.r-universe.dev/tf/badges/version)](https://tidyfun.r-un
 
 The **`tf`** package provides necessary infrastructure for
 [**`tidyfun`**](https://tidyfun.github.io/tidyfun/) with minimal
-dependencies – specifically: no `tidyverse`-dependencies.
+dependencies – `vctrs`/`rlang`/`cli`/`purrr` from the r-lib/tidyverse
+ecosystem, otherwise just `mgcv`, `zoo`, `mvtnorm`, `pracma`,
+`checkmate`.
 
 The goal of **`tidyfun`**, in turn, is to provide accessible and
 well-documented software that **makes functional data analysis in `R`
@@ -104,6 +106,26 @@ differentiated, etc.
 [See
 here](https://tidyfun.github.io/tidyfun/articles/x01_tf_Vectors.html)
 for more information on the operations defined for `tf` vectors.
+
+#### Vector-valued (multivariate) functional data
+
+`tf` also provides `tfd_mv()` and `tfb_mv()` for vector-valued
+functional data – i.e., functions whose codomain is `R^d`, sharing a
+single domain across components. These behave like the univariate `tf`
+classes (subsetting, arithmetic, plotting), with component-wise
+accessors and the geometry verbs `tf_norm()`, `tf_inner()`,
+`tf_tangent()`, `tf_arclength()`:
+
+``` r
+fm <- tfd_mv(list(x = tf_rgp(5), y = tf_rgp(5)))
+plot(fm, type = "facet")
+```
+
+Multivariate FPCA is available via `tfb_mfpc()` (Happ & Greven, 2018),
+and `tf_register()` supports joint multivariate alignment
+(`method = "srvf_mv"`) as well as elastic shape registration
+(`tf_register_shape()`). Note that `is_tf()` is `TRUE` for `tf_mv` as
+well; use the new `is_tf_1d()` to test specifically for univariate `tf`.
 
 #### Methods for converting existing data to `tf` and back
 


### PR DESCRIPTION
Closes #258 (narrowed scope: NEWS + README only; vignette stays in `tidyfun`) and #259.

### #258 — Make the multivariate feature visible

- **NEWS.md**: expanded the 0.4.2 entry into a "Vector-valued functional data" section covering `tfd_mv()`/`tfb_mv()`, `tfb_mfpc()`, `method = "srvf_mv"` + `tf_register_shape()`, the new geometry verbs (`tf_norm`/`tf_inner`/`tf_tangent`/`tf_arclength`), the component accessors (`tf_ncomp()`/`tf_components()`/`tf_component()`), and the **contract change** that `is_tf()` now returns TRUE for `tf_mv` (with `is_tf_1d()` as the new univariate predicate).
- **README.Rmd**: new "Vector-valued (multivariate) functional data" subsection with a minimal `tfd_mv` example and pointers to `tfb_mfpc()` and registration. Softened the previous "no tidyverse-dependencies" claim to honestly list the r-lib imports (`vctrs`/`rlang`/`cli`/`purrr`) alongside the others. README re-knit.

Per maintainer instruction the 1,072-line mv vignette `attic/vector-valued-functions.Rmd` stays in attic and will migrate to the `tidyfun` companion package once `tf_mv` is fixed. `_pkgdown.yml` and `vignettes/` untouched.

### #259 — fdasrvf version floor

- **DESCRIPTION**: `Suggests: fdasrvf (>= 2.4.0)`. Confirmed via upstream NEWS that v2.4.0 reorganized curve functions (`curve_karcher_mean` → `multivariate_karcher_mean` etc.) which the mv-SRVF code depends on.
- **`R/register-mv.R`**: both mv callsites use `rlang::check_installed("fdasrvf", version = "2.4.0", reason = ...)`. Univariate callsite in `R/register.R` retains bare `check_installed("fdasrvf")` since `time_warping`/`pair_align_functions` predate the 2.4.0 reorganization.

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_