### PR TITLE
Hygiene C: dedup backlog — NA helper, cum dispatcher, factories (#260)

### DIFF
--- a/R/calculus.R
+++ b/R/calculus.R
@@ -95,6 +95,19 @@ tf_invert.tfb <- function(x, ...) {
 }
 
 
+# Trapezoidal quadrature weights for a possibly-irregular grid.
+#
+# Contract: given a sorted numeric grid `arg` of length n, returns a length-n
+# weight vector `w` such that for a function sampled on `arg` with values `v`,
+# `sum(w * v)` is the trapezoidal-rule approximation of the integral over
+# `[arg[1], arg[n]]`. Interior weights are the average of the two adjacent
+# `diff(arg)` spacings; boundary weights are half of the single adjacent
+# spacing. The result is invariant to a constant shift of `arg`.
+trapezoid_weights <- function(arg) {
+  delta <- c(0, diff(arg))
+  0.5 * c(delta[-1] + head(delta, -1), tail(delta, 1))
+}
+
 # Reinsert NULL entries for previously missing functions while preserving tf attrs.
 #
 # Contract: `tf_non_na` is a (possibly zero-length) `tf` carrying the desired

--- a/R/calculus.R
+++ b/R/calculus.R
@@ -95,8 +95,21 @@ tf_invert.tfb <- function(x, ...) {
 }
 
 
-# reinsert NULL entries for previously missing functions while preserving tf attrs
-restore_na_entries <- function(tf_non_na, na_entries, names_out) {
+# Reinsert NULL entries for previously missing functions while preserving tf attrs.
+#
+# Contract: `tf_non_na` is a (possibly zero-length) `tf` carrying the desired
+# output attributes (e.g. a freshly rebased `tfb`); `na_entries` is the logical
+# mask of the full-length result; `names_out` are the final names. When some
+# entries are non-NA, those slots are filled from `unclass(tf_non_na)` in order.
+# When every entry is NA, pass `ref_tfb` to supply the attributes (since
+# `tf_non_na` would itself be empty and carry no useful attributes); by default
+# `ref_tfb` falls back to `tf_non_na`.
+restore_na_entries <- function(
+  tf_non_na,
+  na_entries,
+  names_out,
+  ref_tfb = tf_non_na
+) {
   if (!any(na_entries)) {
     return(setNames(tf_non_na, names_out))
   }
@@ -105,7 +118,7 @@ restore_na_entries <- function(tf_non_na, na_entries, names_out) {
     ret[!na_entries] <- unclass(tf_non_na)
   }
   ret[na_entries] <- list(NULL)
-  attributes(ret) <- attributes(tf_non_na)
+  attributes(ret) <- attributes(ref_tfb)
   names(ret) <- names_out
   ret
 }

--- a/R/depth.R
+++ b/R/depth.R
@@ -309,7 +309,7 @@ validate_depth <- function(depth) {
 depth_data <- function(x, depth, na.rm = FALSE, ...) {
   validate_depth(depth)
   if (!na.rm && anyNA(x))
-    return(list(x = 1 * NA * x[which(is.na(x))[1]], d = NULL))
+    return(list(x = tf_na_like(x, which(is.na(x))[1]), d = NULL))
 
   x <- x[!is.na(x)]
   if (length(x) == 0) return(list(x = x, d = NULL))

--- a/R/fwise.R
+++ b/R/fwise.R
@@ -52,35 +52,32 @@ tf_fwise <- function(x, .f, arg = tf_arg(x), ...) {
   setNames(ret, names(x))
 }
 
+# Factory for the function-wise scalar reductions tf_fmax / tf_fmin /
+# tf_fmedian: reduce each function's values with `reduce_op`, unlist the
+# per-function scalars and reattach names.
+make_tf_freduce <- function(reduce_op) {
+  function(x, arg = tf_arg(x), na.rm = FALSE) {
+    x |>
+      tf_fwise(\(.x) reduce_op(.x$value, na.rm = na.rm), arg = arg) |>
+      unlist(use.names = FALSE) |>
+      setNames(names(x))
+  }
+}
+
 #' @export
 #' @describeIn functionwise maximal value of each function
 #' @inheritParams base::min
-tf_fmax <- function(x, arg = tf_arg(x), na.rm = FALSE) {
-  x |>
-    tf_fwise(\(.x) max(.x$value, na.rm = na.rm), arg = arg) |>
-    unlist(use.names = FALSE) |>
-    setNames(names(x))
-}
+tf_fmax <- make_tf_freduce(max)
 
 #' @export
 #' @describeIn functionwise minimal value of each function
 #' @inheritParams base::min
-tf_fmin <- function(x, arg = tf_arg(x), na.rm = FALSE) {
-  x |>
-    tf_fwise(\(.x) min(.x$value, na.rm = na.rm), arg = arg) |>
-    unlist(use.names = FALSE) |>
-    setNames(names(x))
-}
+tf_fmin <- make_tf_freduce(min)
 
 #' @export
 #' @describeIn functionwise median value of each function
 #' @inheritParams base::min
-tf_fmedian <- function(x, arg = tf_arg(x), na.rm = FALSE) {
-  x |>
-    tf_fwise(\(.x) median(.x$value, na.rm = na.rm), arg = arg) |>
-    unlist(use.names = FALSE) |>
-    setNames(names(x))
-}
+tf_fmedian <- make_tf_freduce(stats::median)
 
 #' @export
 #' @describeIn functionwise range of values of each function

--- a/R/math.R
+++ b/R/math.R
@@ -39,32 +39,18 @@ Math.tfb <- function(x, ...) {
   eval <- fun_math(tfd(x), .Generic)
   na_entries <- is.na(eval)
   if (all(na_entries)) {
-    # all entries became NA -- return tfb with NULL entries
-    result <- vector("list", length(eval))
-    result[] <- list(NULL)
-    result_names <- names(eval)
-    attributes(result) <- attributes(x)
-    names(result) <- result_names
-    return(result)
+    return(restore_na_entries(
+      eval[!na_entries],
+      na_entries,
+      names(eval),
+      ref_tfb = x
+    ))
   }
-  if (any(na_entries)) {
-    # refit only non-NA entries, then insert NULLs at NA positions
-    non_na <- do.call(
-      "tfb",
-      c(list(eval[!na_entries]), basis_args, penalized = FALSE, verbose = FALSE)
-    )
-    result <- vector("list", length(eval))
-    result[!na_entries] <- unclass(non_na)
-    result[na_entries] <- list(NULL)
-    result_names <- names(eval)
-    attributes(result) <- attributes(non_na)
-    names(result) <- result_names
-    return(result)
-  }
-  do.call(
+  non_na <- do.call(
     "tfb",
-    c(list(eval), basis_args, penalized = FALSE, verbose = FALSE)
+    c(list(eval[!na_entries]), basis_args, penalized = FALSE, verbose = FALSE)
   )
+  restore_na_entries(non_na, na_entries, names(eval))
 }
 
 #-------------------------------------------------------------------------------

--- a/R/ops.R
+++ b/R/ops.R
@@ -348,16 +348,6 @@ numeric_op_tfd <- function(op, x, y) {
   ret
 }
 
-# construct a tfb shell with NULL entries, using ref_tfb for attributes
-tfb_na_result <- function(eval, ref_tfb) {
-  result <- vector("list", length(eval))
-  result[] <- list(NULL)
-  names(result) <- names(eval)
-  attributes(result) <- attributes(ref_tfb)
-  names(result) <- names(eval)
-  result
-}
-
 #-------------------------------------------------------------------------------
 
 tfb_multdiv_numeric <- function(op, x, y) {
@@ -382,19 +372,21 @@ tfb_op_numeric <- function(op, x, y) {
   )
   eval <- tfd_op_numeric(op, tfd(x), y)
   na_entries <- is.na(eval)
-  if (all(na_entries)) return(tfb_na_result(eval, x))
-  if (any(na_entries)) {
-    rebased <- tf_rebase(
+  if (all(na_entries)) {
+    return(restore_na_entries(
       eval[!na_entries],
-      x[!na_entries],
-      penalized = FALSE,
-      verbose = FALSE
-    )
-    result <- tfb_na_result(eval, rebased)
-    result[!na_entries] <- unclass(rebased)
-    return(result)
+      na_entries,
+      names(eval),
+      ref_tfb = x
+    ))
   }
-  tf_rebase(eval, x, penalized = FALSE, verbose = FALSE)
+  rebased <- tf_rebase(
+    eval[!na_entries],
+    x[!na_entries],
+    penalized = FALSE,
+    verbose = FALSE
+  )
+  restore_na_entries(rebased, na_entries, names(eval))
   #TODO: restore sp afterwards so all properties are preserved?
 }
 
@@ -404,19 +396,21 @@ numeric_op_tfb <- function(op, x, y) {
   )
   eval <- numeric_op_tfd(op, x, tfd(y))
   na_entries <- is.na(eval)
-  if (all(na_entries)) return(tfb_na_result(eval, y))
-  if (any(na_entries)) {
-    rebased <- tf_rebase(
+  if (all(na_entries)) {
+    return(restore_na_entries(
       eval[!na_entries],
-      y[!na_entries],
-      penalized = FALSE,
-      verbose = FALSE
-    )
-    result <- tfb_na_result(eval, rebased)
-    result[!na_entries] <- unclass(rebased)
-    return(result)
+      na_entries,
+      names(eval),
+      ref_tfb = y
+    ))
   }
-  tf_rebase(eval, y, penalized = FALSE, verbose = FALSE) #TODO: see tfb_op_numeric
+  rebased <- tf_rebase(
+    eval[!na_entries],
+    y[!na_entries],
+    penalized = FALSE,
+    verbose = FALSE
+  ) #TODO: see tfb_op_numeric
+  restore_na_entries(rebased, na_entries, names(eval))
 }
 
 tfb_op_tfb <- function(op, x, y) {
@@ -426,19 +420,21 @@ tfb_op_tfb <- function(op, x, y) {
   eval <- tfd_op_tfd(op, tfd(x), tfd(y))
   ret_ptype <- if (vec_size(x) >= vec_size(y)) vec_ptype(x) else vec_ptype(y)
   na_entries <- is.na(eval)
-  if (all(na_entries)) return(tfb_na_result(eval, ret_ptype))
-  if (any(na_entries)) {
-    rebased <- tf_rebase(
+  if (all(na_entries)) {
+    return(restore_na_entries(
       eval[!na_entries],
-      ret_ptype,
-      penalized = FALSE,
-      verbose = FALSE
-    )
-    result <- tfb_na_result(eval, rebased)
-    result[!na_entries] <- unclass(rebased)
-    return(result)
+      na_entries,
+      names(eval),
+      ref_tfb = ret_ptype
+    ))
   }
-  tf_rebase(eval, ret_ptype, penalized = FALSE, verbose = FALSE) #TODO: see tfb_op_numeric
+  rebased <- tf_rebase(
+    eval[!na_entries],
+    ret_ptype,
+    penalized = FALSE,
+    verbose = FALSE
+  ) #TODO: see tfb_op_numeric
+  restore_na_entries(rebased, na_entries, names(eval))
 }
 
 tfb_plusminus_tfb <- function(op, x, y) {

--- a/R/ops.R
+++ b/R/ops.R
@@ -63,14 +63,14 @@ NULL
 #' @export
 `!=.tfd` <- function(e1, e2) !(e1 == e2)
 
-# need to copy instead of defining tf-method s.t. dispatch in Ops works
+# Plain copy so S3 dispatch in Ops picks up a tfb-named method.
 #' @rdname tfgroupgenerics
 #' @export
-`==.tfb` <- eval(`==.tfd`)
+`==.tfb` <- `==.tfd`
 
 #' @rdname tfgroupgenerics
 #' @export
-`!=.tfb` <- eval(`!=.tfd`)
+`!=.tfb` <- `!=.tfd`
 
 #' @rdname tfgroupgenerics
 #' @export

--- a/R/ops.R
+++ b/R/ops.R
@@ -307,45 +307,43 @@ tfd_op_tfd <- function(op, x, y) {
   )
 }
 
-tfd_op_numeric <- function(op, x, y, ...) {
+# Worker for {tfd, numeric} arithmetic that preserves operand order so
+# non-commutative ops (e.g. `/`, `-`, `^`) are correct on either side.
+# `tf_left` indicates which side carries the tfd.
+tfd_numeric_op <- function(op, x, y, tf_left) {
   assert_compatible_size(op, x, y)
-  ret <- map2(tf_evaluations(x), y, \(x, y) {
-    if (is.null(x)) return(NULL)
-    result <- do.call(op, list(x, y))
-    if (allMissing(result)) NULL else result
-  })
-  if (is_irreg(x)) {
-    ret <- map2(tf_arg(x), ret, \(.arg, .ret) {
+  tf_side <- if (tf_left) x else y
+  num_side <- if (tf_left) y else x
+  ret <- map2(
+    if (tf_left) tf_evaluations(tf_side) else num_side,
+    if (tf_left) num_side else tf_evaluations(tf_side),
+    \(a, b) {
+      if (is.null(a) || is.null(b)) return(NULL)
+      result <- do.call(op, list(a, b))
+      if (allMissing(result)) NULL else result
+    }
+  )
+  if (is_irreg(tf_side)) {
+    ret <- map2(tf_arg(tf_side), ret, \(.arg, .ret) {
       if (is.null(.ret)) return(NULL)
       list(arg = .arg, value = .ret)
     })
   }
-  attributes(ret) <- attributes(x)
-  if (vec_size(y) > 1) {
+  attributes(ret) <- attributes(tf_side)
+  if (vec_size(num_side) > 1) {
     names(ret) <- NULL
   }
   ret
 }
 
-# some code-duplication here, this makes non-commutative ops work for tfd and numeric
+tfd_op_numeric <- function(op, x, y, ...) {
+  tfd_numeric_op(op, x, y, tf_left = TRUE)
+}
+
+# Mirror of tfd_op_numeric so non-commutative ops work with the numeric on the
+# left.
 numeric_op_tfd <- function(op, x, y) {
-  assert_compatible_size(op, x, y)
-  ret <- map2(x, tf_evaluations(y), \(x, y) {
-    if (is.null(y)) return(NULL)
-    result <- do.call(op, list(x, y))
-    if (allMissing(result)) NULL else result
-  })
-  if (is_irreg(y)) {
-    ret <- map2(tf_arg(y), ret, \(.arg, .ret) {
-      if (is.null(.ret)) return(NULL)
-      list(arg = .arg, value = .ret)
-    })
-  }
-  attributes(ret) <- attributes(y)
-  if (vec_size(x) > 1) {
-    names(ret) <- NULL
-  }
-  ret
+  tfd_numeric_op(op, x, y, tf_left = FALSE)
 }
 
 #-------------------------------------------------------------------------------
@@ -366,75 +364,58 @@ tfb_multdiv_numeric <- function(op, x, y) {
   ret
 }
 
-tfb_op_numeric <- function(op, x, y) {
-  cli::cli_warn(
-    "Potentially lossy cast to {.cls tfd} and back in {.cls {vec_ptype_full(x)}} {op} {.cls {vec_ptype_full(y)}}."
-  )
-  eval <- tfd_op_numeric(op, tfd(x), y)
+# Shared body for tfb {+,-,*,/,^,%%, %/%} {tfb, numeric}: cast to tfd, run the
+# pre-computed numeric `eval`, then rebase to `rebase_target`. `ref_tfb`
+# supplies attributes for the all-NA branch when `rebase_target` is a length-0
+# ptype.
+#TODO: restore sp afterwards so all properties are preserved?
+tfb_lossy_rebase <- function(eval, rebase_target, ref_tfb = rebase_target) {
   na_entries <- is.na(eval)
   if (all(na_entries)) {
     return(restore_na_entries(
       eval[!na_entries],
       na_entries,
       names(eval),
-      ref_tfb = x
+      ref_tfb = ref_tfb
     ))
+  }
+  rebase_subset <- if (vec_size(rebase_target) > 1) {
+    rebase_target[!na_entries]
+  } else {
+    rebase_target
   }
   rebased <- tf_rebase(
     eval[!na_entries],
-    x[!na_entries],
+    rebase_subset,
     penalized = FALSE,
     verbose = FALSE
   )
   restore_na_entries(rebased, na_entries, names(eval))
-  #TODO: restore sp afterwards so all properties are preserved?
+}
+
+tfb_op_numeric <- function(op, x, y) {
+  cli::cli_warn(
+    "Potentially lossy cast to {.cls tfd} and back in {.cls {vec_ptype_full(x)}} {op} {.cls {vec_ptype_full(y)}}."
+  )
+  tfb_lossy_rebase(tfd_op_numeric(op, tfd(x), y), rebase_target = x)
 }
 
 numeric_op_tfb <- function(op, x, y) {
   cli::cli_warn(
     "Potentially lossy cast to {.cls tfd} and back in {.cls {vec_ptype_full(x)}} {op} {.cls {vec_ptype_full(y)}}."
   )
-  eval <- numeric_op_tfd(op, x, tfd(y))
-  na_entries <- is.na(eval)
-  if (all(na_entries)) {
-    return(restore_na_entries(
-      eval[!na_entries],
-      na_entries,
-      names(eval),
-      ref_tfb = y
-    ))
-  }
-  rebased <- tf_rebase(
-    eval[!na_entries],
-    y[!na_entries],
-    penalized = FALSE,
-    verbose = FALSE
-  ) #TODO: see tfb_op_numeric
-  restore_na_entries(rebased, na_entries, names(eval))
+  tfb_lossy_rebase(numeric_op_tfd(op, x, tfd(y)), rebase_target = y)
 }
 
 tfb_op_tfb <- function(op, x, y) {
   cli::cli_warn(
     "Potentially lossy casts to {.cls tfd} and back for {.cls {vec_ptype_full(x)}} {op} {.cls {vec_ptype_full(y)}}."
   )
-  eval <- tfd_op_tfd(op, tfd(x), tfd(y))
   ret_ptype <- if (vec_size(x) >= vec_size(y)) vec_ptype(x) else vec_ptype(y)
-  na_entries <- is.na(eval)
-  if (all(na_entries)) {
-    return(restore_na_entries(
-      eval[!na_entries],
-      na_entries,
-      names(eval),
-      ref_tfb = ret_ptype
-    ))
-  }
-  rebased <- tf_rebase(
-    eval[!na_entries],
-    ret_ptype,
-    penalized = FALSE,
-    verbose = FALSE
-  ) #TODO: see tfb_op_numeric
-  restore_na_entries(rebased, na_entries, names(eval))
+  tfb_lossy_rebase(
+    tfd_op_tfd(op, tfd(x), tfd(y)),
+    rebase_target = ret_ptype
+  )
 }
 
 tfb_plusminus_tfb <- function(op, x, y) {

--- a/R/registration-class.R
+++ b/R/registration-class.R
@@ -243,8 +243,7 @@ summary.tf_registration <- function(object, ...) {
     \(i) {
       a <- args_list[[i]]
       dev <- abs(inv_warp_evals[[i]] - a)
-      dt <- diff(a)
-      sum((dev[-length(dev)] + dev[-1]) / 2 * dt)
+      sum(trapezoid_weights(a) * dev)
     },
     numeric(1)
   ) /

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -248,51 +248,41 @@ Summary.tf <- function(...) {
   summarize_tf(..., op = .Generic, eval = is_tfd(list(...)[[1]]))
 }
 
-#' @rdname tfgroupgenerics
-#' @export
-cummax.tfd <- function(...) {
-  summarize_tf(..., op = "cummax", eval = TRUE)
+# Single dispatcher for the four cum* Math-group operations across tfd / tfb.
+# Each cum* S3 method below is a thin wrapper that forwards .Generic.
+cum_tf <- function(op, ..., eval) {
+  summarize_tf(..., op = op, eval = eval)
 }
 
 #' @rdname tfgroupgenerics
 #' @export
-cummin.tfd <- function(...) {
-  summarize_tf(..., op = "cummin", eval = TRUE)
-}
+cummax.tfd <- function(...) cum_tf("cummax", ..., eval = TRUE)
 
 #' @rdname tfgroupgenerics
 #' @export
-cumsum.tfd <- function(...) {
-  summarize_tf(..., op = "cumsum", eval = TRUE)
-}
+cummin.tfd <- function(...) cum_tf("cummin", ..., eval = TRUE)
+
+#' @rdname tfgroupgenerics
+#' @export
+cumsum.tfd <- function(...) cum_tf("cumsum", ..., eval = TRUE)
 
 #' @rdname tfgroupgenerics
 #' @export
 #' @family tidyfun compute
-cumprod.tfd <- function(...) {
-  summarize_tf(..., op = "cumprod", eval = TRUE)
-}
+cumprod.tfd <- function(...) cum_tf("cumprod", ..., eval = TRUE)
 
 #' @rdname tfgroupgenerics
 #' @export
-cummax.tfb <- function(...) {
-  summarize_tf(..., op = "cummax", eval = FALSE)
-}
+cummax.tfb <- function(...) cum_tf("cummax", ..., eval = FALSE)
 
 #' @rdname tfgroupgenerics
 #' @export
-cummin.tfb <- function(...) {
-  summarize_tf(..., op = "cummin", eval = FALSE)
-}
+cummin.tfb <- function(...) cum_tf("cummin", ..., eval = FALSE)
 
 #' @rdname tfgroupgenerics
 #' @export
-cumsum.tfb <- function(...) {
-  summarize_tf(..., op = "cumsum", eval = FALSE)
-}
+cumsum.tfb <- function(...) cum_tf("cumsum", ..., eval = FALSE)
 
 #' @rdname tfgroupgenerics
 #' @export
-cumprod.tfb <- function(...) {
-  summarize_tf(..., op = "cumprod", eval = FALSE)
-}
+cumprod.tfb <- function(...) cum_tf("cumprod", ..., eval = FALSE)

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -92,7 +92,7 @@ mean.tf <- function(x, ...) {
 #' @rdname tfsummaries
 median.tf <- function(x, na.rm = FALSE, depth = "MBD", ...) {
   if (!na.rm && anyNA(x)) {
-    return(1 * NA * x[1])
+    return(tf_na_like(x))
   }
   x <- x[!is.na(x)]
   if (is.character(depth) && length(depth) == 1 && depth == "pointwise") {
@@ -206,7 +206,7 @@ fivenum.default <- function(x, na.rm = FALSE, ...) {
 #' @rdname fivenum
 fivenum.tf <- function(x, na.rm = FALSE, depth = "MHI", ...) {
   if (!na.rm && anyNA(x)) {
-    return(1 * NA * x[1])
+    return(tf_na_like(x))
   }
   prepared <- depth_data(x, depth, na.rm = na.rm, ...)
   if (is.null(prepared$d)) {

--- a/R/tfb-fpc-utils.R
+++ b/R/tfb-fpc-utils.R
@@ -49,9 +49,8 @@ fpc_wsvd.matrix <- function(data, arg, pve = 0.995) {
   assert_numeric(arg, any.missing = FALSE, sorted = TRUE, len = ncol(data))
   assert_number(pve, lower = 0, upper = 1)
 
-  delta <- c(0, diff(arg))
   # trapezoid integration weights:
-  weights <- 0.5 * c(delta[-1] + head(delta, -1), tail(delta, 1))
+  weights <- trapezoid_weights(arg)
   mean <- colMeans(data, na.rm = TRUE)
 
   data_wc <- t((t(data) - mean) * sqrt(weights))

--- a/R/tfb-fpc.R
+++ b/R/tfb-fpc.R
@@ -47,8 +47,7 @@ new_tfb_fpc <- function(
     scoring_function <- attr(basis_from, "scoring_function")
 
     # trapezoid integration weights: #TODO generally appropriate or just for wsvd?
-    delta <- c(0, diff(arg))
-    weights <- 0.5 * c(delta[-1] + head(delta, -1), tail(delta, 1))
+    weights <- trapezoid_weights(arg)
     scores <- scoring_function(
       df_2_mat(data),
       basis_matrix[, -1],

--- a/R/tfb-mfpc.R
+++ b/R/tfb-mfpc.R
@@ -367,11 +367,6 @@ new_tfb_fpc_shared <- function(
   )
 }
 
-# trapezoidal quadrature weights for a (possibly non-equidistant) grid.
-mfpc_quad_weights <- function(arg) {
-  delta <- c(0, diff(arg))
-  0.5 * c(delta[-1] + head(delta, -1), tail(delta, 1))
-}
 
 # per-component scoring stub: scoring a *single* MFPC component is ill-defined
 # (the eigenfunctions are orthonormal only in the joint weighted product), so
@@ -425,7 +420,7 @@ mfpc_rescore <- function(newdata, mfpc_obj, arg = NULL) {
       ))
     }
     mat <- mat[, idx, drop = FALSE]
-    quad_w <- mfpc_quad_weights(u$arg)
+    quad_w <- trapezoid_weights(u$arg)
     as.matrix(u$scoring_function(mat, u$efunctions, u$mu, quad_w))
   })
   xi_new <- do.call(cbind, xi_new)

--- a/R/utils.R
+++ b/R/utils.R
@@ -35,6 +35,13 @@ find_arg <- function(data, arg) {
   list(arg)
 }
 
+# A length-1 NA-valued tf with the same attributes / domain / arg as `x[i]`.
+# Uses the `1 * NA * <tf>` arithmetic dispatch so attributes propagate correctly
+# for both tfd and tfb.
+tf_na_like <- function(x, i = 1L) {
+  1 * NA * x[i]
+}
+
 domains_overlap <- function(x, y) {
   dom_x <- tf_domain(x)
   dom_y <- tf_domain(y)

--- a/tests/testthat/test-mfpc.R
+++ b/tests/testthat/test-mfpc.R
@@ -44,7 +44,7 @@ test_that("multivariate eigenfunctions are weighted-orthonormal", {
   for (j in seq_len(tf_ncomp(ef))) {
     mat <- as.matrix(tf_component(ef, j))
     arg <- as.numeric(attr(mat, "arg"))
-    qw <- tf:::trapezoid_weights(arg)
+    qw <- trapezoid_weights(arg)
     gram <- gram + w[j] * (mat %*% (qw * t(mat)))
   }
   expect_equal(unname(gram), diag(M), tolerance = 1e-6)

--- a/tests/testthat/test-mfpc.R
+++ b/tests/testthat/test-mfpc.R
@@ -44,8 +44,7 @@ test_that("multivariate eigenfunctions are weighted-orthonormal", {
   for (j in seq_len(tf_ncomp(ef))) {
     mat <- as.matrix(tf_component(ef, j))
     arg <- as.numeric(attr(mat, "arg"))
-    delta <- c(0, diff(arg))
-    qw <- 0.5 * c(delta[-1] + head(delta, -1), tail(delta, 1))
+    qw <- tf:::trapezoid_weights(arg)
     gram <- gram + w[j] * (mat %*% (qw * t(mat)))
   }
   expect_equal(unname(gram), diag(M), tolerance = 1e-6)

--- a/tests/testthat/test-ops.R
+++ b/tests/testthat/test-ops.R
@@ -172,3 +172,14 @@ test_that("tfb arithmetic operations with other tfb", {
   expect_no_error(x + x[1])
   expect_no_error(x[3] + x)
 })
+
+test_that("==.tfb dispatches like ==.tfd (PR C target 7)", {
+  xb <- suppressWarnings(tfb(tf_rgp(3)))
+  # `xb == xb` should be a length-3 logical TRUE (per-curve, with NA where either side is NA)
+  expect_equal(xb == xb, !is.na(xb))
+  # Inequality:
+  expect_equal(xb != xb, is.na(xb))   # only TRUE where one side is NA
+  # Mixed:
+  yb <- xb
+  expect_equal(xb == yb, !is.na(xb))
+})

--- a/tests/testthat/test-ops.R
+++ b/tests/testthat/test-ops.R
@@ -175,11 +175,14 @@ test_that("tfb arithmetic operations with other tfb", {
 
 test_that("==.tfb dispatches like ==.tfd (PR C target 7)", {
   xb <- suppressWarnings(tfb(tf_rgp(3)))
-  # `xb == xb` should be a length-3 logical TRUE (per-curve, with NA where either side is NA)
-  expect_equal(xb == xb, !is.na(xb))
-  # Inequality:
-  expect_equal(xb != xb, is.na(xb))   # only TRUE where one side is NA
-  # Mixed:
   yb <- xb
-  expect_equal(xb == yb, !is.na(xb))
+  yb[2] <- NA
+  # Comparison is per-curve via isTRUE(all.equal()) and never returns NA:
+  # an NA entry compares equal to itself and unequal to any non-NA entry.
+  expect_equal(unname(xb == xb), rep(TRUE, 3))
+  expect_equal(unname(xb != xb), rep(FALSE, 3))
+  expect_equal(unname(yb == yb), rep(TRUE, 3))
+  expect_equal(unname(yb != yb), rep(FALSE, 3))
+  expect_equal(unname(xb == yb), c(TRUE, FALSE, TRUE))
+  expect_equal(unname(xb != yb), c(FALSE, TRUE, FALSE))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -22,3 +22,34 @@ test_that("format_bib", {
   bibentries <- list(checkmate = citation("checkmate"), R = citation())
   expect_string(format_bib("checkmate", "R"))
 })
+
+test_that("trapezoid_weights matches the trapezoidal rule", {
+  # On an equidistant grid all interior weights equal the spacing,
+  # boundary weights equal half the spacing -> the discrete integral
+  # of v == 1 on [0, 1] is 1.
+  arg <- seq(0, 1, length.out = 11)
+  w <- trapezoid_weights(arg)
+  expect_equal(sum(w), 1)
+  expect_equal(w[1], 0.05)
+  expect_equal(w[length(w)], 0.05)
+  expect_true(all(abs(w[2:10] - 0.1) < 1e-12))
+
+  # On a non-equidistant grid, weights still integrate constant 1 to the
+  # domain length and weights equal the average of adjacent spacings interior,
+  # half-spacings at the boundary.
+  arg <- c(0, 0.1, 0.3, 0.7, 1)
+  w <- trapezoid_weights(arg)
+  expect_equal(sum(w), 1)
+  expect_equal(w[1], 0.05)
+  expect_equal(w[5], 0.15)
+  expect_equal(w[2], 0.15)
+  expect_equal(w[3], 0.3)
+  expect_equal(w[4], 0.35)
+
+  # Equivalence with the by-hand sum((dev[-n] + dev[-1])/2 * dt) formulation.
+  set.seed(42)
+  v <- runif(5)
+  dt <- diff(arg)
+  by_hand <- sum((v[-length(v)] + v[-1]) / 2 * dt)
+  expect_equal(sum(w * v), by_hand)
+})


### PR DESCRIPTION
Part 3 of 4 for #260 (duplication backlog). Mechanical refactor, semantics preserved; net **-25 LOC** in `R/`.

| Target | Helper | Home file |
|---|---|---|
| 1 | `restore_na_entries()` (unified) | `R/calculus.R` |
| 2 | `tf_na_like(x, i)` | `R/utils.R` |
| 3 | `cum_tf()` dispatcher (collapses 8 stubs) | `R/summarize.R` |
| 4 | `make_tf_freduce()` factory (`tf_fmax`/`tf_fmin`/`tf_fmedian`) | `R/fwise.R` |
| 5 | `tfd_numeric_op()` + `tfb_lossy_rebase()` factories | `R/ops.R` |
| 6 | `trapezoid_weights()` (replaces 4 in-package + 1 in-test copy) | `R/calculus.R` |
| 7 | Plain `==.tfb <- ==.tfd` (was `eval(==.tfd)` — a no-op dressed as a copy) | `R/ops.R` |

Each target is one commit; existing test suite passes after every commit. New tests pin invariants on the helpers + a direct `==.tfb` regression test.

`quad_trapez` (cumulative trapezoid) and `trap_weights` (sum-to-1 normalization in `depth.R`) deliberately NOT consolidated with `trapezoid_weights()` — different semantics.

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_