### PR TITLE
Fix: allow NA-domain prototypes through validate_tf (urgent, CI red)

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -144,12 +144,13 @@ validate_tf <- function(x) {
   }
   # ---- domain (all tf subclasses) -----------------------------------------
   domain <- attr(x, "domain")
-  # length-0 prototypes legitimately carry a degenerate domain c(0, 0); only
-  # check non-degeneracy / sortedness for non-empty objects.
+  # length-0 prototypes legitimately carry a degenerate domain — c(0, 0) (tfb
+  # path) or c(NA, NA) (tfd path, matching the S4 prototype); only require
+  # the structural shape (length-2 numeric) for prototypes.
   is_proto <- length(unclass(x)) == 0L
   bad_domain <- !is.numeric(domain) || length(domain) != 2L ||
-    anyNA(domain) || any(!is.finite(domain)) || domain[1] > domain[2] ||
-    (!is_proto && length(unique(domain)) != 2L)
+    (!is_proto && (anyNA(domain) || any(!is.finite(domain)) ||
+       domain[1] > domain[2] || length(unique(domain)) != 2L))
   if (bad_domain) {
     cli::cli_abort(paste0(
       "Invalid {.field domain}: must be a finite, sorted length-2 numeric ",

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -144,9 +144,9 @@ validate_tf <- function(x) {
   }
   # ---- domain (all tf subclasses) -----------------------------------------
   domain <- attr(x, "domain")
-  # length-0 prototypes legitimately carry a degenerate domain — c(0, 0) (tfb
-  # path) or c(NA, NA) (tfd path, matching the S4 prototype); only require
-  # the structural shape (length-2 numeric) for prototypes.
+  # length-0 prototypes legitimately carry a degenerate domain — numeric(2) (= c(0, 0))
+  # in the tfb constructors, or c(NA_real_, NA_real_) in the tfd constructors (matching
+  # the S4 prototype); only require the structural shape (length-2 numeric) for prototypes.
   is_proto <- length(unclass(x)) == 0L
   bad_domain <- !is.numeric(domain) || length(domain) != 2L ||
     (!is_proto && (anyNA(domain) || any(!is.finite(domain)) ||


### PR DESCRIPTION
**Urgent — fixes CI red on the mv branch.**

Interaction between two already-merged PRs:
- **#267** (constructor invariants) reconciled the empty `tfd()` prototype's domain to `c(NA_real_, NA_real_)` so it matches the S4 prototype (a deliberate fix).
- **#277** (`validate_tf`) added a universal domain check that unconditionally rejects `anyNA(domain) || any(!is.finite(domain))`.

Neither PR saw the other on its base branch, so the conflict only surfaced after both merged. Now `validate_tf()` (called via `expect_valid_tf()` in many test files) rejects the package's own empty `tfd` prototype.

### Fix

In `R/assertions.R::validate_tf`, skip the NA / finiteness / sortedness / distinct-endpoint checks for length-0 prototypes — keep only the structural shape requirement (length-2 numeric). Non-empty objects are unchanged.

This mirrors the existing length-0 short-circuit pattern in `validate_tfb_spline`/`validate_tfb_fpc` (added per copilot review on #277), but it has to live in `validate_tf` itself because that's where the universal domain check fires before subclass dispatch.

### Failing tests (now passing)

- `test-tfd-class.R:64` — "tfd.numeric works"
- `test-validate-tf.R:60` — "validate_tf accepts length-0 prototypes of all subclasses"

Full `devtools::test()` clean.

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_