### PR TITLE
Fix: drop unresolvable \link{} targets in tf_mv_unimplemented docs (urgent, CI red)

### DIFF
--- a/R/mv-stubs.R
+++ b/R/mv-stubs.R
@@ -112,7 +112,7 @@ tf_jiggle.tf_mv <- function(f, ...) mv_unimplemented("tf_jiggle")
 #' generic reuse continue to work. **Behaviour** on `tf_mv` objects, however,
 #' is supplied *only* by explicitly registered `.tf_mv` methods: any generic
 #' without one aborts with a classed `tf_mv_method_unimplemented` condition
-#' (see [tf_where.tf_mv()], [summary.tf_mv()], ...). This avoids silent
+#' (e.g. `tf_where(<tf_mv>)`, `summary(<tf_mv>)`). This avoids silent
 #' fall-through to the univariate method, which would otherwise produce
 #' wrong-shape results or deep internal errors.
 #'

--- a/R/mv-stubs.R
+++ b/R/mv-stubs.R
@@ -112,7 +112,7 @@ tf_jiggle.tf_mv <- function(f, ...) mv_unimplemented("tf_jiggle")
 #' generic reuse continue to work. **Behaviour** on `tf_mv` objects, however,
 #' is supplied *only* by explicitly registered `.tf_mv` methods: any generic
 #' without one aborts with a classed `tf_mv_method_unimplemented` condition
-#' (e.g. `tf_where(<tf_mv>)`, `summary(<tf_mv>)`). This avoids silent
+#' (e.g. `tf_where(<tf_mv>, <cond>)`, `summary(<tf_mv>)`). This avoids silent
 #' fall-through to the univariate method, which would otherwise produce
 #' wrong-shape results or deep internal errors.
 #'

--- a/man/tf_mv_unimplemented.Rd
+++ b/man/tf_mv_unimplemented.Rd
@@ -9,7 +9,7 @@
 generic reuse continue to work. \strong{Behaviour} on \code{tf_mv} objects, however,
 is supplied \emph{only} by explicitly registered \code{.tf_mv} methods: any generic
 without one aborts with a classed \code{tf_mv_method_unimplemented} condition
-(see \code{\link[=tf_where.tf_mv]{tf_where.tf_mv()}}, \code{\link[=summary.tf_mv]{summary.tf_mv()}}, ...). This avoids silent
+(e.g. \code{tf_where(<tf_mv>)}, \code{summary(<tf_mv>)}). This avoids silent
 fall-through to the univariate method, which would otherwise produce
 wrong-shape results or deep internal errors.
 }

--- a/man/tf_mv_unimplemented.Rd
+++ b/man/tf_mv_unimplemented.Rd
@@ -9,7 +9,7 @@
 generic reuse continue to work. \strong{Behaviour} on \code{tf_mv} objects, however,
 is supplied \emph{only} by explicitly registered \code{.tf_mv} methods: any generic
 without one aborts with a classed \code{tf_mv_method_unimplemented} condition
-(e.g. \code{tf_where(<tf_mv>)}, \code{summary(<tf_mv>)}). This avoids silent
+(e.g. \code{tf_where(<tf_mv>, <cond>)}, \code{summary(<tf_mv>)}). This avoids silent
 fall-through to the univariate method, which would otherwise produce
 wrong-shape results or deep internal errors.
 }


### PR DESCRIPTION
**Urgent — fixes CI red on the mv branch (R CMD check WARNING with `error-on: "warning"`).**

PR #276 (mv stubs) introduced roxygen `[tf_where.tf_mv()]` / `[summary.tf_mv()]` links in `R/mv-stubs.R`'s package-level docs. Those are S3 method names, not exported Rd topics, so roxygen converts them to `\link[=tf_where.tf_mv]{...}` and `R CMD check --as-cran` flags them as missing-anchor links:

```
* checking Rd cross-references ... WARNING
Missing link(s) in Rd file 'tf_mv_unimplemented.Rd':
  'tf_where.tf_mv' 'summary.tf_mv'
```

The check workflow uses `error-on: "warning"`, so this fails CI across all OS matrices (`macos-latest`, `ubuntu-latest`, `windows-latest`, devel/release/oldrel-1).

### Fix

Replace the misleading links with plain inline code — `tf_where(<tf_mv>)` / `summary(<tf_mv>)` — which conveys the same example without inventing links to non-topics. Hand-patched both `R/mv-stubs.R` and the generated `man/tf_mv_unimplemented.Rd` (no roxygen regen to avoid the version-drift churn).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_