### PR TITLE
Fix: drop orphan prep_plotting_arg entry from _pkgdown.yml (urgent, pkgdown CI red)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -68,7 +68,6 @@ reference:
   contents:
   - plot.tf
   - print.tf
-  - prep_plotting_arg
 - title: Querying functional data
   desc: Locating functional features like peaks or zero-crossings
   contents:


### PR DESCRIPTION
**Urgent — fixes the pkgdown CI failure introduced by #281.**

PR #281 (hygiene B cleanup) made `prep_plotting_arg` internal and deleted `man/prep_plotting_arg.Rd`, but left the entry in `_pkgdown.yml`'s reference index. The pkgdown build aborts:

```
✖ Reference metadata not ok.
  In _pkgdown.yml, reference[7].contents[3] (prep_plotting_arg) must be a known
  topic name or alias.

Error in `build_reference_index()`:
! In _pkgdown.yml, reference[7].contents[3] (prep_plotting_arg) must be
  a known topic name or alias.
```

### Fix

One-line removal of the orphan reference entry. `ensure_list` and `unique_id` stay (they remain exported — #281 verified tidyfun depends on those).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_