### PR TITLE
Fix: use trapezoid_weights() in new_tfb_fpc_demoted (urgent, CI red)

### DIFF
--- a/R/tfb-mfpc.R
+++ b/R/tfb-mfpc.R
@@ -420,7 +420,7 @@ new_tfb_fpc_demoted <- function(component, uni) {
   joint_bm <- attr(component, "basis_matrix") # n_arg x (1 + M)
   coefs_old <- do.call(rbind, unclass(component)) # n x (1 + M)
   data_matrix <- coefs_old %*% t(joint_bm) # n x n_arg
-  quad_w <- mfpc_quad_weights(arg)
+  quad_w <- trapezoid_weights(arg)
   scores <- as.matrix(scoring_function(data_matrix, phi_j, mu_j, quad_w))
   basis_matrix <- unname(cbind(mu_j, phi_j))
   domain <- attr(component, "domain")


### PR DESCRIPTION
**Urgent — fixes 9 test failures + CI red on the mv branch.**

Interaction bug from two already-merged PRs:

- **#278** (mfpc invariants) introduced `new_tfb_fpc_demoted()` in `R/tfb-mfpc.R`, which calls `mfpc_quad_weights(arg)` to build trapezoid quadrature weights.
- **#282** (hygiene C dedup) consolidated the four quadrature-weight implementations into a single internal `trapezoid_weights()` helper in `R/calculus.R` and removed `mfpc_quad_weights`.

Both merged without detecting the semantic conflict (the rebase succeeded textually because they touch adjacent but non-overlapping lines), so all `tfb_mfpc` demote paths now abort with `could not find function "mfpc_quad_weights"`.

### Fix

One-line change: `mfpc_quad_weights(arg)` → `trapezoid_weights(arg)`. Same math, just the new helper name (the elsewhere-in-the-file call at line 526 already uses `trapezoid_weights`; only this one stale call survived).

### Failing tests now passing

- `test-mfpc.R:174` — `tfb_mfpc protects its joint spec` (`mf + 1`)
- `test-mfpc.R:193` — `post-demotion tfb_mv stays functional` (`$<-` demote)
- `test-mfpc.R:211` — `both-mfpc arithmetic warns about demotion exactly once`
- `test-mfpc.R:226–229` — `demoted tfb_mfpc supports chained Math/Ops` (4 cases: `(mf+1)-1`, `log(mf+2)`, `-mf`, `mf*2/2`)
- `test-mfpc.R:231` — finite-values assertion (dependent on 226)
- `test-mfpc.R:239` — `demotion warning has class 'tf_mfpc_demotion'`

Local `devtools::test(filter = "mfpc")` clean after the patch.

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_