### PR TITLE
Fix #262: all-NA list input to tfd() preserves vec_size

### DIFF
--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -344,7 +344,12 @@ tfd.list <- function(
   vectors <- map_lgl(data, \(x) is.null(x) || (is.numeric(x) & !is.array(x)))
   if (all(vectors)) {
     where_na <- map(data, is.na)
+    # non-empty all-NA entries become NULL markers (tf's NA representation) so
+    # new_tfd routes an all-NA input to the NA-functions branch instead of
+    # collapsing to a length-0 prototype (matches the matrix path, #262).
+    all_na <- map_lgl(where_na, \(y) length(y) > 0 && all(y))
     data <- map2(data, where_na, \(x, y) x[!y])
+    data[all_na] <- list(NULL)
     lens <- lengths(data)
     nonempty <- lens != 0
     # arg-length probe: derive the shared arg-vector length (if any) we'd

--- a/tests/testthat/test-tfd-class.R
+++ b/tests/testthat/test-tfd-class.R
@@ -159,6 +159,20 @@ test_that("all-NA input yields length-n NA functions, not length-0 (#241)", {
   expect_true(all(is.na(f)))
 })
 
+test_that("all-NA list input preserves vec_size (#262)", {
+  x <- suppressWarnings(tfd(list(NA_real_, NA_real_), arg = list(c(1, 2), c(1, 2))))
+  expect_length(x, 2)
+  expect_true(all(is.na(x)))
+  expect_warning(tfd(list(NA_real_, NA_real_), arg = list(c(1, 2), c(1, 2))), "NA")
+  # mixed NA and real entries keep working
+  y <- suppressWarnings(tfd(list(NA_real_, c(1, 2)), arg = list(c(1, 2), c(1, 2))))
+  expect_length(y, 2)
+  expect_equal(is.na(y), c(TRUE, FALSE))
+  # validate_tf() accepts the result
+  expect_valid_tf(x)
+  expect_valid_tf(y)
+})
+
 test_that("tfd() length-0 prototype uses NA sentinel domain (#241)", {
   f <- tfd(numeric())
   expect_identical(attr(f, "domain"), c(NA_real_, NA_real_))


### PR DESCRIPTION
Closes #262.

`tfd.list` NA-stripped each entry to `numeric(0)`, so all-NA input hit `new_tfd`'s `truly_empty` branch and returned the length-0 prototype — silently collapsing a size-2 input to size 0 (asymmetric with the matrix path, fixed for it in #241/#267).

### Fix

In `tfd.list`, non-empty all-NA entries are set to `NULL` (tf's NA representation) after stripping, which makes `truly_empty` false and routes the input through `new_tfd`'s existing all-NA branch — same `warn_na_entries_created()` warning, same NA-function representation, same arg handling as the matrix path. Partial-NA entries still get NA-stripped, genuinely-empty input still returns the prototype.

The data.frame path was checked and is unaffected (it never strips NA rows, so it already reached the all-NA branch).

Reviewed (LGTM): repro fixed; no regression for empty/mixed/partial-NA inputs; `list(NULL, NULL)` behavior unchanged; warning identical to the matrix path; `expect_valid_tf()` in the regression test.

Review also surfaced a pre-existing separate bug: `tfd(list())` errors "subscript out of bounds" — filed separately.

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_