### PR TITLE
Extract shared bracket index/j helpers for [.tf and [.tf_mv (#263)

### DIFF
--- a/R/brackets-mv.R
+++ b/R/brackets-mv.R
@@ -87,32 +87,19 @@ tf_evaluate.tf_mv <- function(object, arg, ...) {
     return(ret)
   }
 
-  # Validate `i` the same way univariate `[.tf` does (no NA, no missing names,
-  # no out-of-bounds). TODO(#263): replace with a shared helper that also
-  # handles `j`-normalisation, to remove the duplication with `[.tf`.
-  if (missing(i)) {
-    i <- seq_along(x)
-  } else {
-    i <- vec_as_location(
-      i,
-      n = vec_size(x),
-      names = names(x),
-      missing = "error"
-    )
-  }
+  i <- tf_bracket_i(x, i)
   xi <- vec_slice(x, i)
 
-  if (missing(j) && missing(matrix)) {
-    return(xi)
-  }
-  if (missing(j) && !missing(matrix) && isFALSE(matrix)) {
-    j <- tf_mv_curve_grids(xi)
+  if (missing(j)) {
+    if (missing(matrix)) {
+      return(xi)
+    }
+    j <- tf_bracket_j(tf_mv_curve_grids(xi), matrix)
   }
 
   comps_i <- tf_components(xi)
   n_i <- vec_size(xi)
   if (matrix) {
-    if (missing(j)) j <- sort_unique(tf_mv_curve_grids(xi), simplify = TRUE)
     if (!length(comps_i) || n_i == 0L) {
       return(array(
         numeric(0),

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -42,6 +42,52 @@
 #'   columns `arg` = `j` and `value` = evaluations at `j` for each observation
 #'   in `i`.
 #'
+# Shared bracket helpers -------------------------------------------------------
+# Extraction-only helpers used by both `[.tf` and `[.tf_mv`. They must not
+# collapse or simplify the intentional four-mode dispatch of `[.tf`; each caller
+# keeps its own matrix-`i` decomposition and result-shaping (see #263).
+
+# Contract: normalise a bracket row-index `i` to positive integer locations
+# against `x`, enforcing the package's strict bracket rules (no NA, no unknown
+# names, no out-of-bounds; `missing = "error"`). A missing `i` selects every
+# element. `matrix_i = TRUE` is the decomposed-matrix case (`i` is already the
+# integer function-index column of a 2-column matrix): it is nameless and must
+# be a plain positive integer position, so negatives/zeros/NA are rejected.
+tf_bracket_i <- function(x, i, matrix_i = FALSE) {
+  if (missing(i)) {
+    return(seq_along(x))
+  }
+  if (matrix_i) {
+    num_as_location(
+      i,
+      n = vec_size(x),
+      missing = "error",
+      negative = "error",
+      zero = "error"
+    )
+  } else {
+    vec_as_location(
+      i,
+      n = vec_size(x),
+      names = names(x),
+      missing = "error"
+    )
+  }
+}
+
+# Contract: compute the default `arg` grid `j` when the caller omits `j` but
+# still asks for evaluations (i.e. `matrix` was given). `grid` is the object's
+# native argument grid (`tf_arg()` for `tf`, per-curve grids for `tf_mv`).
+# `matrix = TRUE` requires a single shared vector, so a per-curve (list) grid is
+# collapsed to its sorted union; otherwise the per-curve grid is kept as-is.
+tf_bracket_j <- function(grid, matrix) {
+  if (isTRUE(matrix) && is.list(grid)) {
+    sort_unique(grid, simplify = TRUE)
+  } else {
+    grid
+  }
+}
+
 #' @rdname tfbrackets
 #' @name tfbrackets
 #' @export
@@ -91,40 +137,13 @@
     matrix <- FALSE
   }
   # handle i
-  if (missing(i)) {
-    i <- seq_along(x)
-  } else if (matrix_i) {
-    i <- num_as_location(
-      i,
-      n = vec_size(x),
-      missing = "error",
-      negative = "error",
-      zero = "error"
-    )
-  } else {
-    i <- vec_as_location(
-      i,
-      n = vec_size(x),
-      names = names(x),
-      missing = "error"
-    )
-  }
+  i <- tf_bracket_i(x, i, matrix_i)
   x <- vec_slice(x, i)
   if (missing(j)) {
-    if (!missing(matrix)) {
-      if (isTRUE(matrix)) {
-        arg_vals <- tf_arg(x)
-        if (is.list(arg_vals)) {
-          j <- sort_unique(arg_vals, simplify = TRUE)
-        } else {
-          j <- arg_vals
-        }
-      } else {
-        j <- tf_arg(x)
-      }
-    } else {
+    if (missing(matrix)) {
       return(x)
     }
+    j <- tf_bracket_j(tf_arg(x), matrix)
   }
 
   # handle j

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -80,6 +80,8 @@ tf_bracket_i <- function(x, i, matrix_i = FALSE) {
 # native argument grid (`tf_arg()` for `tf`, per-curve grids for `tf_mv`).
 # `matrix = TRUE` requires a single shared vector, so a per-curve (list) grid is
 # collapsed to its sorted union; otherwise the per-curve grid is kept as-is.
+# The tf_mv caller relies on `tf_mv_curve_grids()` ALWAYS returning a list —
+# an atomic grid from that path would silently skip the union-collapse here.
 tf_bracket_j <- function(grid, matrix) {
   if (isTRUE(matrix) && is.list(grid)) {
     sort_unique(grid, simplify = TRUE)


### PR DESCRIPTION
Closes #263.

Extraction-only refactor: the duplicated bracket index-validation and default-`j` logic in `[.tf` and `[.tf_mv` now lives in two shared internal helpers in `R/brackets.R`:

- **`tf_bracket_i(x, i, matrix_i)`** — normalizes a bracket row-index under the strict bracket rules (`vec_as_location(missing = "error")`: no NA, no OOB, no unknown names); `matrix_i = TRUE` routes the decomposed matrix-index column through `num_as_location` (negatives/zeros rejected as before).
- **`tf_bracket_j(grid, matrix)`** — default `arg` grid when `j` is omitted but evaluation is requested; collapses per-curve (list) grids to their sorted union for `matrix = TRUE`.

**The four-mode `[.tf` dispatch is untouched** (`x[i]` → tf, `x[i, j]` → matrix, `x[i, j, matrix = FALSE]` → list of data frames, `x[cbind(i, j)]` → numeric, `missing(j)` introspection) — per the maintainer's explicit constraint on #263 that this design is intentional and preserved.

### Non-regression evidence

- Full `devtools::test()` passes with **zero modifications to any existing test file**.
- 34-case behavior pin (18 univariate + 16 tf_mv, covering all four modes plus negative/logical/named/empty indices and j-only calls) run on both branches: `str()` output identical modulo srcfile environment addresses.
- Error-path parity verified: NA index, OOB, unknown name — same classes and messages.
- Reviewer specifically probed the `missing()` propagation through the helper (the classic footgun): safe — no default on `i`, tested before touching, promise never forced upstream.

`TODO(#263)` marker removed. Net +6 LOC (helpers + contract comments minus dedup).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_