### PR TITLE
Registration numerics: domain preservation, same-template objective, in-loop scale equalization (#264, #265, #266)

### DIFF
--- a/R/register-mv.R
+++ b/R/register-mv.R
@@ -206,14 +206,21 @@ srvf_mv_gamma_to_warps <- function(gamma, arg, domain, curve_names = NULL) {
 # convention, so we correct it on our side here.
 #
 # We renormalise every returned aligned curve to a shared (mean) arc length, so
-# congruent shapes overlay as they should. The per-curve scale factors that were
-# removed are reported separately and left untouched in `tf_scales()`.
+# congruent shapes overlay as they should. The per-curve scale factors that
+# relate the equalised aligned curves back to the input curves' sizes are
+# reported by `tf_scales()` (see `tf_register_shape_srvf_mv()`).
 # `beta` is `[component, arg, curve]`.
-srvf_mv_equalize_scale <- function(beta) {
-  arclen <- apply(beta, 3, function(m) {
+
+# Per-curve (polyline) arc lengths of a `[component, arg, curve]` array.
+srvf_mv_arclengths <- function(beta) {
+  apply(beta, 3, function(m) {
     d <- m[, -1, drop = FALSE] - m[, -ncol(m), drop = FALSE]
     sum(sqrt(colSums(d^2)))
   })
+}
+
+srvf_mv_equalize_scale <- function(beta) {
+  arclen <- srvf_mv_arclengths(beta)
   target <- mean(arclen)
   for (k in seq_len(dim(beta)[3])) {
     if (arclen[k] > 0) {
@@ -319,12 +326,15 @@ tf_register_srvf_mv <- function(
 #' and scale factors.
 #'
 #' @details
-#' The per-curve scale factors returned by [tf_scales()] are expressed
-#' *relative to the template*: each is the ratio of the template's SRVF norm to
-#' the curve's own SRVF norm, so a value `> 1` means the curve was scaled up to
-#' match the template and `< 1` means it was scaled down. With `template = NULL`
-#' the returned [tf_template()] is the empirical mean of the aligned shape-space
-#' curves rather than any single input curve.
+#' When `scale = TRUE` the aligned curves returned by [tf_aligned()] are
+#' renormalised to a common (mean) arc length so that congruent shapes overlay.
+#' The per-curve factors returned by [tf_scales()] are the sizes that were
+#' removed: multiplying an aligned curve by its scale factor rescales it back to
+#' the corresponding input curve's arc length, so a value `> 1` means the input
+#' curve was larger than the shared aligned size and `< 1` means it was smaller.
+#' With `scale = FALSE` warping and rotation preserve arc length, so all factors
+#' are `1`. With `template = NULL` the returned [tf_template()] is the empirical
+#' mean of the aligned shape-space curves rather than any single input curve.
 #'
 #' Only open curves (`mode = "O"`) are supported. Closed curves (`mode = "C"`)
 #' additionally optimise over a circular seed shift that the returned warping
@@ -463,6 +473,7 @@ tf_register_shape_srvf_mv <- function(
   comp_names <- attr(x, "comp_names")
   curve_names <- names(x)
   beta <- srvf_mv_to_array(x)
+  input_arclen <- srvf_mv_arclengths(beta)
   current_template <- if (is.null(template)) {
     beta[,, 1]
   } else {
@@ -488,6 +499,12 @@ tf_register_shape_srvf_mv <- function(
         dots
       )
     ))
+    if (scale) {
+      # fdasrvf returns scale-aligned curves at the wrong (inverted) size; see
+      # srvf_mv_equalize_scale() above. Renormalise BEFORE the template update
+      # so intermediate templates are built from correctly-scaled curves (#264).
+      ret$betan <- srvf_mv_equalize_scale(ret$betan)
+    }
     new_template <- rowMeans(ret$betan, dims = 2)
     best <- ret
     best_template <- new_template
@@ -505,15 +522,19 @@ tf_register_shape_srvf_mv <- function(
     current_template <- new_template
   }
 
-  if (scale) {
-    # fdasrvf returns scale-aligned curves at the wrong (inverted) size; see
-    # srvf_mv_equalize_scale() above. Renormalise, then refresh the template.
-    best$betan <- srvf_mv_equalize_scale(best$betan)
-    best_template <- rowMeans(best$betan, dims = 2)
-  }
-
   warps <- srvf_mv_gamma_to_warps(best$gamma, arg, domain, curve_names)
-  scales <- if (scale) best$qmean_norm / best$len_q else rep(1, length(x))
+  # Report the per-curve factors that actually reconstruct the input sizes:
+  # the equalised aligned curves share a common arc length, so multiplying an
+  # aligned curve by `input_arclen / aligned_arclen` recovers its input arc
+  # length. This keeps `tf_scales()` mutually consistent with `tf_aligned()`
+  # (#264). With `scale = FALSE` warping and rotation preserve arc length, so
+  # the factors are 1.
+  scales <- if (scale) {
+    aligned_arclen <- srvf_mv_arclengths(best$betan)
+    ifelse(aligned_arclen > 0, input_arclen / aligned_arclen, 1)
+  } else {
+    rep(1, length(x))
+  }
   names(scales) <- curve_names
   rotations <- best$R
   dimnames(rotations) <- list(comp_names, comp_names, curve_names)

--- a/R/register.R
+++ b/R/register.R
@@ -605,19 +605,24 @@ tf_estimate_warps.tfd_reg <- function(
     )
     # Fix the averaged-over curve subset ONCE (first finite iteration) so the
     # mean objective is comparable across iterations rather than averaging over
-    # a curve set that changes with each iteration's NA pattern (#265).
+    # a curve set that changes with each iteration's NA pattern (#265). A kept
+    # curve may still turn non-finite in a *later* iteration, so restrict to
+    # the currently finite kept curves -- otherwise a single such curve NAs the
+    # mean and silently disables objective tracking for the rest of the run.
     if (is.null(keep) && any(is.finite(obj_vec))) {
       keep <- is.finite(obj_vec)
     }
-    subset <- keep %||% is.finite(obj_vec)
+    subset <- (keep %||% TRUE) & is.finite(obj_vec)
     obj <- if (any(subset)) mean(obj_vec[subset]) else NA_real_
 
     if (is.finite(obj)) {
       # Same-template comparison (#265): score BOTH the current and the previous
       # iterate against the CURRENT (refined) template. Comparing against an
       # objective measured against an OLDER template is meaningless because
-      # objectives across different templates are not comparable.
-      prev_obj_ct <- NA_real_
+      # objectives across different templates are not comparable. Within the
+      # comparison, both means must cover the SAME curves, so restrict to the
+      # pairwise-finite kept subset rather than na.rm-ing each side separately.
+      prev_obj_ct <- obj_ct <- NA_real_
       if (!is.null(prev_aligned)) {
         prev_obj_vec <- outer_registration_objective(
           method = method,
@@ -626,17 +631,17 @@ tf_estimate_warps.tfd_reg <- function(
           arg = arg,
           dots = dots
         )
-        prev_obj_ct <- if (any(subset)) {
-          mean(prev_obj_vec[subset])
-        } else {
-          NA_real_
+        pair <- subset & is.finite(prev_obj_vec)
+        if (any(pair)) {
+          obj_ct <- mean(obj_vec[pair])
+          prev_obj_ct <- mean(prev_obj_vec[pair])
         }
       }
       worsened <- is.finite(prev_obj_ct) &&
-        obj > prev_obj_ct * (1 + sqrt(.Machine$double.eps))
+        obj_ct > prev_obj_ct * (1 + sqrt(.Machine$double.eps))
       if (worsened) {
         cli::cli_inform(
-          "Iterative registration stopped after {iter - 1} of {max_iter} iteration{?s}: alignment worsened (objective {round(obj, 4)} > {round(prev_obj_ct, 4)} against the current template)."
+          "Iterative registration stopped after {iter - 1} of {max_iter} iteration{?s}: alignment worsened (objective {round(obj_ct, 4)} > {round(prev_obj_ct, 4)} against the current template)."
         )
         warps <- best_warps %||% warps
         break

--- a/R/register.R
+++ b/R/register.R
@@ -81,7 +81,10 @@ tf_warp.tfd <- function(x, warp, ..., keep_new_arg = FALSE) {
   ret <- tfd(tf_evaluations(x), warp_evals, domain = domain, ...)
 
   if (!keep_new_arg) {
-    ret <- tfd(ret, arg = arg, ...)
+    # Carry the INPUT's domain so warped results keep `tf_domain(x)` (#266).
+    dots <- list(...)
+    dots$domain <- dots$domain %||% domain
+    ret <- do.call(tfd, c(list(ret, arg = arg), dots))
   }
   ret
 }
@@ -158,8 +161,11 @@ tf_align.tfd <- function(x, warp, ..., keep_new_arg = FALSE) {
     )
 
     if (!keep_new_arg) {
-      # Re-evaluate on regular grid (evaluator returns NA outside valid range)
-      ret <- tfd(ret, arg = arg, ...)
+      # Re-evaluate on regular grid (evaluator returns NA outside valid range).
+      # Carry the INPUT's domain so aligned results keep `tf_domain(x)` (#266).
+      dots <- list(...)
+      dots$domain <- dots$domain %||% domain
+      ret <- do.call(tfd, c(list(ret, arg = arg), dots))
     }
     return(ret)
   } else {
@@ -171,7 +177,10 @@ tf_align.tfd <- function(x, warp, ..., keep_new_arg = FALSE) {
       domain = domain
     )
     if (!keep_new_arg) {
-      ret <- tfd(ret, arg = arg, ...)
+      # Carry the INPUT's domain so aligned results keep `tf_domain(x)` (#266).
+      dots <- list(...)
+      dots$domain <- dots$domain %||% domain
+      ret <- do.call(tfd, c(list(ret, arg = arg), dots))
     }
     return(ret)
   }
@@ -284,9 +293,17 @@ tf_register <- function(
   tmpl <- attr(warps, "template") %||%
     (if (method != "landmark") template) %||%
     suppressWarnings(mean(registered))
+  # Represent inverse warps on the INPUT's domain (#266). For non-domain-
+  # preserving (affine) warps the inverse's natural argument (observed time)
+  # extends beyond the data domain; restrict it to `tf_domain(x)` so the
+  # returned warps are h^{-1}: T -> T, consistent with `registered`.
+  inv_warps <- tf_invert(warps)
+  inv_warps <- suppressWarnings(
+    tfd(inv_warps, arg = tf_arg(x), domain = tf_domain(x))
+  )
   new_tf_registration(
     registered = registered,
-    inv_warps = tf_invert(warps),
+    inv_warps = inv_warps,
     template = tmpl,
     x = if (store_x) x else NULL,
     call = cl
@@ -615,7 +632,11 @@ tf_estimate_warps.tfd_reg <- function(
     if (any(missing_tmpl)) {
       new_tmpl_vec[missing_tmpl] <- old_vec[missing_tmpl]
     }
-    new_template <- tfd(matrix(new_tmpl_vec, nrow = 1), arg = arg)
+    new_template <- tfd(
+      matrix(new_tmpl_vec, nrow = 1),
+      arg = arg,
+      domain = tf_domain(x)
+    )
     if (method != "cc") {
       domain_length <- diff(tf_domain(x))
       delta <- suppressWarnings(
@@ -820,7 +841,7 @@ tf_register_landmark <- function(x, landmarks, template_landmarks = NULL) {
     # Fast path: all landmarks present, vectorized construction
     template_arg <- c(domain[1], template_landmarks, domain[2])
     warp_values <- cbind(domain[1], landmarks, domain[2])
-    return(tfd(warp_values, arg = template_arg))
+    return(tfd(warp_values, arg = template_arg, domain = domain))
   }
 
   # NA-aware path: build per-curve warps using only available landmarks
@@ -828,7 +849,8 @@ tf_register_landmark <- function(x, landmarks, template_landmarks = NULL) {
   warp_list <- lapply(seq_len(n), \(i) {
     warp_on_arg(landmarks[i, ], arg)
   })
-  tfd(do.call(rbind, warp_list), arg = arg)
+  # Warps must carry the INPUT's domain, not `range(arg)` (#266).
+  tfd(do.call(rbind, warp_list), arg = arg, domain = domain)
 }
 
 #-------------------------------------------------------------------------------
@@ -883,7 +905,9 @@ tf_register_affine <- function(
   ) |>
     do.call(what = rbind)
 
-  result <- tfd(warp_mat, arg = arg)
+  # Warps must carry the INPUT's domain, not `range(arg)`, so that
+  # downstream `tf_align()` / `assert_warp()` see a matching domain (#266).
+  result <- tfd(warp_mat, arg = arg, domain = domain)
   attr(result, "template") <- template
   result
 }

--- a/R/register.R
+++ b/R/register.R
@@ -312,33 +312,51 @@ tf_register <- function(
 
 #-------------------------------------------------------------------------------
 
-registration_objective_cc <- function(aligned, template, crit = 2L) {
+# Per-curve CC registration criterion (one value per aligned curve).
+registration_objective_cc_percurve <- function(aligned, template, crit = 2L) {
   aligned_mat <- as.matrix(aligned)
   template_mat <- as.matrix(template)
   if (nrow(template_mat) == 1L && nrow(aligned_mat) > 1L) {
     template_mat <- template_mat[rep(1L, nrow(aligned_mat)), , drop = FALSE]
   }
 
-  total <- 0
-  for (i in seq_len(nrow(aligned_mat))) {
-    y0 <- template_mat[i, ]
-    y1 <- aligned_mat[i, ]
-    aa <- mean(y0^2)
-    bb <- mean(y0 * y1)
-    cc <- mean(y1^2)
-    total <- total +
+  vapply(
+    seq_len(nrow(aligned_mat)),
+    \(i) {
+      y0 <- template_mat[i, ]
+      y1 <- aligned_mat[i, ]
+      aa <- mean(y0^2)
+      bb <- mean(y0 * y1)
+      cc <- mean(y1^2)
       if (crit == 1L) {
         aa - 2 * bb + cc
       } else {
         aa + cc - sqrt((aa - cc)^2 + 4 * bb^2)
       }
-  }
-  total
+    },
+    numeric(1)
+  )
 }
 
+registration_objective_cc <- function(aligned, template, crit = 2L) {
+  sum(registration_objective_cc_percurve(aligned, template, crit = crit))
+}
+
+# Per-curve outer objective used to monitor Procrustes template refinement.
+# Returns one value per curve (NA where a curve's objective is undefined) so
+# the caller can hold the averaged-over curve subset FIXED across iterations
+# (#265) and compare objectives measured against the *same* template.
+#
+# For `method = "srvf"` this is a plain L2 amplitude distance while the inner
+# fdasrvf step minimises the Fisher-Rao metric -- a mismatch. In practice the
+# srvf branch never reaches the multi-iteration outer loop: with `template =
+# NULL` the Karcher-mean path returns early, and a user-supplied template forces
+# `max_iter <- 1L`, so this objective is never used to accept/reject an srvf
+# iterate. The L2 fallback is therefore harmless here; if the outer loop is ever
+# enabled for srvf, switch to an amplitude (Fisher-Rao) distance instead (#265).
 outer_registration_objective <- function(method, aligned, template, arg, dots) {
   if (method == "cc") {
-    return(registration_objective_cc(
+    return(registration_objective_cc_percurve(
       aligned = aligned,
       template = template,
       crit = dots$crit %||% 2L
@@ -346,9 +364,8 @@ outer_registration_objective <- function(method, aligned, template, arg, dots) {
   }
 
   domain_length <- diff(tf_domain(aligned))
-  suppressWarnings(mean(
-    tf_integrate((aligned - template)^2, arg = arg) / domain_length,
-    na.rm = TRUE
+  suppressWarnings(as.numeric(
+    tf_integrate((aligned - template)^2, arg = arg) / domain_length
   ))
 }
 
@@ -553,6 +570,8 @@ tf_estimate_warps.tfd_reg <- function(
   best_template <- current_template
   best_obj <- Inf
   prev_obj <- NA_real_
+  prev_aligned <- NULL # previous iterate's aligned curves (on `arg`) (#265)
+  keep <- NULL # fixed subset of curves with a finite objective (#265)
   cc_min_iter <- 3L
   for (iter in seq_len(max_iter)) {
     warps <- switch(
@@ -576,22 +595,50 @@ tf_estimate_warps.tfd_reg <- function(
     template_on_arg <- suppressWarnings(tfd(current_template, arg = arg))
     template_vec <- tf_evaluate(template_on_arg, arg = arg)[[1]]
 
-    obj <- outer_registration_objective(
+    # Per-curve objective of the CURRENT iterate vs the CURRENT template.
+    obj_vec <- outer_registration_objective(
       method = method,
       aligned = aligned_on_arg,
       template = template_on_arg,
       arg = arg,
       dots = dots
     )
+    # Fix the averaged-over curve subset ONCE (first finite iteration) so the
+    # mean objective is comparable across iterations rather than averaging over
+    # a curve set that changes with each iteration's NA pattern (#265).
+    if (is.null(keep) && any(is.finite(obj_vec))) {
+      keep <- is.finite(obj_vec)
+    }
+    subset <- keep %||% is.finite(obj_vec)
+    obj <- if (any(subset)) mean(obj_vec[subset]) else NA_real_
+
     if (is.finite(obj)) {
-      if (
-        is.finite(best_obj) &&
-          obj > best_obj * (1 + sqrt(.Machine$double.eps))
-      ) {
-        cli::cli_inform(
-          "Iterative registration stopped after {iter - 1} of {max_iter} iteration{?s}: alignment worsened (objective {round(obj, 4)} > {round(best_obj, 4)})."
+      # Same-template comparison (#265): score BOTH the current and the previous
+      # iterate against the CURRENT (refined) template. Comparing against an
+      # objective measured against an OLDER template is meaningless because
+      # objectives across different templates are not comparable.
+      prev_obj_ct <- NA_real_
+      if (!is.null(prev_aligned)) {
+        prev_obj_vec <- outer_registration_objective(
+          method = method,
+          aligned = prev_aligned,
+          template = template_on_arg,
+          arg = arg,
+          dots = dots
         )
-        warps <- best_warps
+        prev_obj_ct <- if (any(subset)) {
+          mean(prev_obj_vec[subset])
+        } else {
+          NA_real_
+        }
+      }
+      worsened <- is.finite(prev_obj_ct) &&
+        obj > prev_obj_ct * (1 + sqrt(.Machine$double.eps))
+      if (worsened) {
+        cli::cli_inform(
+          "Iterative registration stopped after {iter - 1} of {max_iter} iteration{?s}: alignment worsened (objective {round(obj, 4)} > {round(prev_obj_ct, 4)} against the current template)."
+        )
+        warps <- best_warps %||% warps
         break
       }
       best_warps <- warps
@@ -614,6 +661,7 @@ tf_estimate_warps.tfd_reg <- function(
       }
     }
     prev_obj <- obj
+    prev_aligned <- aligned_on_arg
 
     if (iter == max_iter) {
       if (max_iter > 1L) {

--- a/man/tf_register_shape.Rd
+++ b/man/tf_register_shape.Rd
@@ -58,12 +58,15 @@ aligned curves live in centered shape space and the result stores rotations
 and scale factors.
 }
 \details{
-The per-curve scale factors returned by \code{\link[=tf_scales]{tf_scales()}} are expressed
-\emph{relative to the template}: each is the ratio of the template's SRVF norm to
-the curve's own SRVF norm, so a value \verb{> 1} means the curve was scaled up to
-match the template and \verb{< 1} means it was scaled down. With \code{template = NULL}
-the returned \code{\link[=tf_template]{tf_template()}} is the empirical mean of the aligned shape-space
-curves rather than any single input curve.
+When \code{scale = TRUE} the aligned curves returned by \code{\link[=tf_aligned]{tf_aligned()}} are
+renormalised to a common (mean) arc length so that congruent shapes overlay.
+The per-curve factors returned by \code{\link[=tf_scales]{tf_scales()}} are the sizes that were
+removed: multiplying an aligned curve by its scale factor rescales it back to
+the corresponding input curve's arc length, so a value \verb{> 1} means the input
+curve was larger than the shared aligned size and \verb{< 1} means it was smaller.
+With \code{scale = FALSE} warping and rotation preserve arc length, so all factors
+are \code{1}. With \code{template = NULL} the returned \code{\link[=tf_template]{tf_template()}} is the empirical
+mean of the aligned shape-space curves rather than any single input curve.
 
 Only open curves (\code{mode = "O"}) are supported. Closed curves (\code{mode = "C"})
 additionally optimise over a circular seed shift that the returned warping

--- a/tests/testthat/test-register-mv-srvf.R
+++ b/tests/testthat/test-register-mv-srvf.R
@@ -128,6 +128,36 @@ test_that("tf_register_shape aligns translated, rotated, and scaled curves", {
   )
 })
 
+test_that("tf_scales rescales aligned curves back to input arc lengths (#264)", {
+  skip_if_not_installed("fdasrvf")
+
+  f <- make_shape_mv()
+  reg <- tf_register_shape(f, max_iter = 3)
+
+  arclen <- function(mv) {
+    beta <- tf:::srvf_mv_to_array(mv)
+    tf:::srvf_mv_arclengths(beta)
+  }
+
+  input_arclen <- arclen(f)
+  aligned_arclen <- arclen(tf_aligned(reg))
+  scales <- unname(tf_scales(reg))
+
+  # The reported per-curve scales must be mutually consistent with the aligned
+  # curves: scaling each aligned curve by its factor recovers the input curve's
+  # arc length. Equalization now happens inside the refinement loop (#264).
+  expect_equal(
+    aligned_arclen * scales,
+    unname(input_arclen),
+    tolerance = 1e-6
+  )
+  # Equalization makes the aligned curves share a common arc length.
+  expect_lt(
+    sd(aligned_arclen) / mean(aligned_arclen),
+    1e-6
+  )
+})
+
 test_that("tf_register_shape rejects closed-curve mode", {
   skip_if_not_installed("fdasrvf")
 

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -1433,3 +1433,46 @@ test_that("registration keeps the input domain when wider than arg range (#266)"
   expect_identical(tf_domain(tf_aligned(reg_lm)), tf_domain(x))
   expect_identical(tf_domain(tf_inv_warps(reg_lm)), tf_domain(x))
 })
+
+test_that("affine Procrustes loop does not spuriously stop on iteration 1 (#265)", {
+  withr::local_seed(7)
+  t <- seq(0, 2 * pi, length.out = 101)
+  shifts <- c(-0.6, -0.3, 0, 0.3, 0.6)
+  x <- tfd(t(sapply(shifts, \(s) sin(t + s))), arg = t)
+
+  # Genuine improvement must be allowed to continue past the first iteration:
+  # no "alignment worsened" message on iteration 1.
+  msgs <- character(0)
+  withCallingHandlers(
+    quiet_expected_registration_warnings(
+      tf_estimate_warps(x, method = "affine", type = "shift", max_iter = 5L)
+    ),
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_false(any(grepl("stopped after 1 of", msgs)))
+
+  # Objective evaluated against a FIXED final template is non-increasing across
+  # accepted iterations: objectives across templates are now comparable (#265).
+  reg_final <- quiet_expected_registration_warnings(
+    tf_register(x, method = "affine", type = "shift", max_iter = 8L)
+  )
+  tmpl <- tf_template(reg_final)
+  objs <- vapply(
+    1:5,
+    \(k) {
+      w <- quiet_expected_registration_warnings(
+        tf_estimate_warps(x, method = "affine", type = "shift", max_iter = k)
+      )
+      al <- suppressWarnings(tf_interpolate(tf_align(x, w), arg = t))
+      suppressWarnings(mean(
+        tf_integrate((al - tmpl)^2, arg = t),
+        na.rm = TRUE
+      ))
+    },
+    numeric(1)
+  )
+  expect_true(all(diff(objs) <= 1e-8))
+})

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -1391,3 +1391,45 @@ test_that("SRVF with template=NULL gives same result regardless of max_iter", {
   w5 <- tf_estimate_warps(x, method = "srvf", max_iter = 5L)
   expect_equal(as.matrix(w1), as.matrix(w5))
 })
+
+test_that("registration keeps the input domain when wider than arg range (#266)", {
+  withr::local_seed(1)
+  f <- tfd(
+    tf_rgp(3, arg = seq(0.1, 0.9, length.out = 9)),
+    domain = c(0, 1)
+  )
+
+  # The affine repro used to hard-error in assert_warp() because the estimated
+  # warps carried domain range(arg) instead of tf_domain(x).
+  reg <- quiet_expected_registration_warnings(
+    tf_register(f, method = "affine")
+  )
+  expect_identical(tf_domain(tf_aligned(reg)), c(0, 1))
+  expect_identical(tf_domain(tf_inv_warps(reg)), c(0, 1))
+
+  # Estimated warps carry the input domain; #242: their VALUES for affine may
+  # extend outside range(arg) but must stay monotone.
+  warps <- quiet_expected_registration_warnings(
+    tf_estimate_warps(f, method = "affine")
+  )
+  expect_identical(tf_domain(warps), c(0, 1))
+  expect_true(all(vapply(
+    tf_evaluations(warps),
+    \(v) all(diff(v) > 0),
+    logical(1)
+  )))
+
+  # Landmark method on a wide domain keeps the input domain too.
+  t <- seq(0, 2 * pi, length.out = 101)
+  x <- tfd(
+    t(sapply(c(-0.3, 0, 0.3), \(s) sin(t + s))),
+    arg = t,
+    domain = c(-1, 2 * pi + 1)
+  )
+  peaks <- tf_landmarks_extrema(x, "max")
+  reg_lm <- quiet_expected_registration_warnings(
+    tf_register(x, method = "landmark", landmarks = peaks)
+  )
+  expect_identical(tf_domain(tf_aligned(reg_lm)), tf_domain(x))
+  expect_identical(tf_domain(tf_inv_warps(reg_lm)), tf_domain(x))
+})


### PR DESCRIPTION
Closes #264, closes #265, closes #266.

### #266 — warps and aligned results carry the input domain (gating bug)

With `domain` wider than `range(arg)`, `tf_register(f, method = "affine")` hard-errored in `assert_warp` ("`x` and `warp` must have the same domain") because warps were built with domain `range(arg)`. Fixed by passing `domain = tf_domain(x)` at every warp/template/result `tfd()` construction (affine + landmark warp constructors, refined template, `tf_warp`/`tf_align` re-evaluation, inverse warps). Warp *values* still stay within `range(arg)` — #242 not regressed (its test still passes).

Note on inverse warps: the affine inverse is genuinely undefined past the observed range, so re-expressing it on the input domain yields NA outside `range(arg)` → a sparse irregular inverse warp. Mathematically correct (no extrapolation), reviewer-verified.

### #265 — same-template objective comparison in the Procrustes loop

The "alignment worsened" early-stop compared this iteration's objective (vs the refined template) against the previous iteration's (vs the *old* template) — not comparable. Now the previous iterate is re-scored against the *current* template (same `outer_registration_objective` helper) before comparing. NA curves are dropped once at the first finite iteration and the subset held fixed, so means are comparable across iterations.

Evidence: objective vs a fixed final template non-increasing across `max_iter = 1..5` (`3.7e-5, 3e-6, 3e-6, 3e-6, 3e-6`); the CC pinch test that previously logged "stopped after 1 of 10 iterations" now continues to 4 of 10; genuine worsening still stops. One extra objective evaluation per iteration — bounded by small `max_iter`.

Behavior note: worsening is now judged against the immediately previous iterate rather than best-ever — benign for monotone Procrustes refinement.

### #264 — srvf_mv scale equalization inside the loop

`srvf_mv_equalize_scale()` now runs before each `rowMeans(betan)` template update instead of once after the loop, so intermediate templates aren't built from wrongly-scaled curves. Zero-length-curve guard retained; upstream fdasrvf bug reference kept. `tf_scales()` now reports input-arclength / aligned-arclength, so `tf_scales()` and `tf_aligned()` are mutually consistent (the inconsistency called out in the original review).

⚠️ **fdasrvf is not installed in the dev container**, so the #264 path and srvf tests were verified by inspection + reviewed by inspection; tests carry `skip_if_not_installed("fdasrvf")`. The affine/landmark paths (#265, #266) were verified by running. Worth one CI cycle with fdasrvf present before merging.

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_