### PR TITLE
tf_mv verbs: quantile + points implemented, tf_invert permanently stubbed (#255 follow-up)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,14 @@ univariate `tfd`/`tfb` classes.
   conditions across components, referenced by name (e.g.
   `tf_where(f, x > 0 & y < 1)`); there is no `value` column for `tf_mv` input.
   Components must share a common grid, or `arg` must be supplied explicitly.
+* `quantile()` works on `tf_mv` objects, returning the *component-wise*
+  pointwise quantiles: a `tf_mv` with one curve per requested probability in
+  `probs`, exactly as `quantile.tf()` does per component (`na.rm` / `probs` /
+  `type` are forwarded).
+* `points()` works on `tf_mv` objects, mirroring `lines.tf_mv()`: in
+  `"trajectory"` mode (`d == 2`) it overlays the paired `(x(t), y(t))` points
+  with per-curve graphical-parameter recycling; in `"facet"` mode it overlays
+  each component onto the current device.
 
 ### Contract change
 

--- a/R/depth.R
+++ b/R/depth.R
@@ -535,3 +535,34 @@ quantile.tf <- function(
     ...
   )
 }
+
+# Component-wise pointwise quantiles for vector-valued functional data: returns
+# a `tf_mv` with one curve per requested probability in `probs`, exactly as
+# `quantile.tf()` produces per component. The per-component `cli_inform()` about
+# "only pointwise quantiles" is suppressed and emitted once here instead.
+#' @export
+quantile.tf_mv <- function(
+  x,
+  probs = seq(0, 1, 0.25),
+  na.rm = FALSE,
+  names = TRUE,
+  type = 7,
+  ...
+) {
+  cli::cli_inform(c(
+    i = "Only pointwise, non-functional quantiles implemented for {.cls tf}s;
+         returned component-wise for {.cls tf_mv}."
+  ))
+  comps <- map(tf_components(x), function(comp) {
+    suppressMessages(quantile(
+      comp,
+      probs = probs,
+      na.rm = na.rm,
+      names = names,
+      type = type,
+      ...
+    ))
+  })
+  names(comps) <- attr(x, "comp_names")
+  new_tf_mv(comps, domain = tf_domain(x))
+}

--- a/R/mv-stubs.R
+++ b/R/mv-stubs.R
@@ -52,10 +52,26 @@ sort.tf_mv <- function(x, decreasing = FALSE, ...) mv_unimplemented("sort")
 
 # `points.tf_mv` is implemented in R/plot-mv.R (mirroring `lines.tf_mv`).
 
-# ---- approx.R: tf_invert -----------------------------------------------------
+# ---- calculus.R: tf_invert (permanently undefined) ---------------------------
+# Function inversion is only defined for monotone *scalar* functions. A
+# vector-valued f: R -> R^d has no inverse in this sense, so this is not a
+# "not yet" stub but a permanent one -- we keep the `tf_mv_method_unimplemented`
+# class (the walker contract test relies on it) but give a definitive message.
 
 #' @export
-tf_invert.tf_mv <- function(x, ...) mv_unimplemented("tf_invert")
+tf_invert.tf_mv <- function(x, ...) {
+  cli::cli_abort(
+    c(
+      "{.fn tf_invert} is not defined for vector-valued {.cls tf_mv}.",
+      i = "Inversion requires a monotone scalar function; a vector-valued
+           {.cls tf_mv} has no such inverse.",
+      i = "If a single component is monotone, invert it per component, e.g.
+           {.code tf_invert(f$x)}."
+    ),
+    class = "tf_mv_method_unimplemented",
+    call = NULL
+  )
+}
 
 # ---- fwise.R: tf_crosscov / tf_crosscor --------------------------------------
 # Converted to generics in fwise.R (default method retains the univariate body).
@@ -79,6 +95,13 @@ tf_crosscor.tf_mv <- function(x, y, ...) mv_unimplemented("tf_crosscor")
 #'
 #' Real component-wise semantics (joint vs. per-component, norm-based, ...) are
 #' being designed verb-by-verb in <https://github.com/tidyfun/tf/issues/255>.
+#' `summary()`, `fivenum()`, `rank()`, `xtfrm()`, `sort()` and `tf_depth()`
+#' await the multivariate-depth design in
+#' <https://github.com/tidyfun/tf/issues/273>, and `tf_crosscov()` /
+#' `tf_crosscor()` await <https://github.com/tidyfun/tf/issues/274>.
+#' `tf_invert()` is *permanently* undefined for `tf_mv`: function inversion
+#' requires a monotone scalar function, which a vector-valued `f: R -> R^d`
+#' is not (invert a monotone component instead, e.g. `tf_invert(f$x)`).
 #'
 #' @name tf_mv_unimplemented
 #' @keywords internal

--- a/R/mv-stubs.R
+++ b/R/mv-stubs.R
@@ -50,10 +50,7 @@ xtfrm.tf_mv <- function(x) mv_unimplemented("xtfrm")
 #' @export
 sort.tf_mv <- function(x, decreasing = FALSE, ...) mv_unimplemented("sort")
 
-# ---- graphics.R: points ------------------------------------------------------
-
-#' @export
-points.tf_mv <- function(x, ...) mv_unimplemented("points")
+# `points.tf_mv` is implemented in R/plot-mv.R (mirroring `lines.tf_mv`).
 
 # ---- approx.R: tf_invert -----------------------------------------------------
 

--- a/R/mv-stubs.R
+++ b/R/mv-stubs.R
@@ -31,8 +31,8 @@ summary.tf_mv <- function(object, ...) mv_unimplemented("summary")
 #' @export
 fivenum.tf_mv <- function(x, na.rm = FALSE, ...) mv_unimplemented("fivenum")
 
-#' @export
-quantile.tf_mv <- function(x, ...) mv_unimplemented("quantile")
+# `quantile.tf_mv` is implemented component-wise in R/depth.R (next to
+# `quantile.tf`).
 
 # ---- depth.R: tf_depth, rank, xtfrm, sort -----------------------------------
 # (`min`/`max`/`range` are handled by the existing `Summary.tf_mv` group method;

--- a/R/plot-mv.R
+++ b/R/plot-mv.R
@@ -17,12 +17,15 @@ mv_paired_xy <- function(x) {
                   dimnames = dimnames(arr)[1:2]))
 }
 
-# Draw each curve (row of mx/my) as a column of a matrix so that matlines()
-# recycles col/lty/lwd/... across curves -- matching univariate plot.tf().
-# A single lines() call per curve would only honour the first element of e.g.
-# `col`, so passing `col = 1:n` would draw every curve in the same colour.
-# `alpha` (if given) tints the line colour(s) -- consistent with plot.tf().
-draw_trajectory <- function(mx, my, dots) {
+# Draw each curve (row of mx/my) as a column of a matrix so that matlines() /
+# matpoints() recycles col/lty/lwd/... across curves -- matching univariate
+# plot.tf(). A single lines()/points() call per curve would only honour the
+# first element of e.g. `col`, so passing `col = 1:n` would draw every curve in
+# the same colour. `alpha` (if given) tints the line/point colour(s) --
+# consistent with plot.tf(). `mat_fun` selects lines (default) vs. points; it
+# is the only thing that differs between lines.tf_mv() and points.tf_mv() in
+# trajectory mode.
+draw_trajectory <- function(mx, my, dots, mat_fun = graphics::matlines) {
   line_args <- modifyList(
     list(col = 1, lty = 1),
     dots[intersect(names(dots), traj_curve_par)]
@@ -30,7 +33,7 @@ draw_trajectory <- function(mx, my, dots) {
   if (!is.null(dots$alpha)) {
     line_args$col <- grDevices::adjustcolor(line_args$col, alpha.f = dots$alpha)
   }
-  do.call(graphics::matlines, c(list(t(mx), t(my)), line_args))
+  do.call(mat_fun, c(list(t(mx), t(my)), line_args))
 }
 
 # default display: "trajectory" for 2-d curves (the movement-data view),
@@ -128,5 +131,23 @@ lines.tf_mv <- function(x, ..., type = NULL) {
     return(invisible(x))
   }
   walk(comps, \(comp) graphics::lines(comp, ...))
+  invisible(x)
+}
+
+#' @rdname plot.tf_mv
+#' @importFrom graphics points matpoints
+#' @export
+points.tf_mv <- function(x, ..., type = NULL) {
+  comps <- tf_components(x)
+  type <- mv_plot_type(type, comps)
+  if (type == "trajectory" && length(comps) == 2) {
+    xy <- mv_paired_xy(x)
+    draw_trajectory(xy$x, xy$y, list(...), mat_fun = graphics::matpoints)
+    return(invisible(x))
+  }
+  # facet mode: like lines.tf_mv(), overlay each component onto the *current*
+  # device -- there is no way to re-enter plot.tf_mv()'s per-component facets
+  # after par(mfrow) was reset, so this layers all components onto one plot.
+  walk(comps, \(comp) graphics::points(comp, ...))
   invisible(x)
 }

--- a/man/tf_mv_unimplemented.Rd
+++ b/man/tf_mv_unimplemented.Rd
@@ -16,5 +16,12 @@ wrong-shape results or deep internal errors.
 \details{
 Real component-wise semantics (joint vs. per-component, norm-based, ...) are
 being designed verb-by-verb in \url{https://github.com/tidyfun/tf/issues/255}.
+\code{summary()}, \code{fivenum()}, \code{rank()}, \code{xtfrm()}, \code{sort()} and \code{tf_depth()}
+await the multivariate-depth design in
+\url{https://github.com/tidyfun/tf/issues/273}, and \code{tf_crosscov()} /
+\code{tf_crosscor()} await \url{https://github.com/tidyfun/tf/issues/274}.
+\code{tf_invert()} is \emph{permanently} undefined for \code{tf_mv}: function inversion
+requires a monotone scalar function, which a vector-valued \verb{f: R -> R^d}
+is not (invert a monotone component instead, e.g. \code{tf_invert(f$x)}).
 }
 \keyword{internal}

--- a/man/tf_mv_unimplemented.Rd
+++ b/man/tf_mv_unimplemented.Rd
@@ -21,7 +21,7 @@ await the multivariate-depth design in
 \url{https://github.com/tidyfun/tf/issues/273}, and \code{tf_crosscov()} /
 \code{tf_crosscor()} await \url{https://github.com/tidyfun/tf/issues/274}.
 \code{tf_invert()} is \emph{permanently} undefined for \code{tf_mv}: function inversion
-requires a monotone scalar function, which a vector-valued \verb{f: R -> R^d}
+requires a monotone scalar function, which a vector-valued \code{f: R -> R^d}
 is not (invert a monotone component instead, e.g. \code{tf_invert(f$x)}).
 }
 \keyword{internal}

--- a/tests/testthat/test-mv-contract.R
+++ b/tests/testthat/test-mv-contract.R
@@ -192,7 +192,6 @@ mv_probe_calls <- function(fm) {
   list(
     summary = function() summary(fm),
     fivenum = function() fivenum(fm),
-    quantile = function() quantile(fm),
     tf_depth = function() tf_depth(fm),
     tf_crosscov = function() tf_crosscov(fm, fm),
     tf_crosscor = function() tf_crosscor(fm, fm),
@@ -217,6 +216,15 @@ test_that("explicitly probed unimplemented verbs abort with classed condition", 
       )
     )
   }
+})
+
+test_that("quantile() on a tf_mv now succeeds (implemented component-wise)", {
+  set.seed(2551)
+  fm <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))
+  expect_no_condition(
+    suppressMessages(quantile(fm)),
+    class = "tf_mv_method_unimplemented"
+  )
 })
 
 test_that("every univariate-tf generic either has a tf_mv method or aborts cleanly", {

--- a/tests/testthat/test-mv-methods.R
+++ b/tests/testthat/test-mv-methods.R
@@ -227,6 +227,26 @@ test_that("trajectory plotting handles components on different / irregular grids
   expect_no_error(plot(irr))
 })
 
+test_that("points.tf_mv overlays without error in trajectory and facet modes", {
+  set.seed(88)
+  f2 <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))
+  f3 <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3), z = tf_rgp(3)))
+  pf <- withr::local_tempfile(fileext = ".pdf")
+  grDevices::pdf(pf)
+  on.exit(grDevices::dev.off(), add = TRUE)
+  # trajectory (default for d == 2), incl. per-curve col recycling
+  plot(f2)
+  expect_no_error(points(f2, col = 1:3))
+  # facet default for d > 2; points overlay onto current device
+  plot(f3)
+  expect_no_error(points(f3))
+  # mirrors lines.tf_mv(): a trajectory request for d != 2 silently falls back
+  # to per-component overlay (only plot.tf_mv() errors on that), no error here
+  expect_no_error(points(f3, type = "trajectory"))
+  # returns its input invisibly
+  expect_identical(points(f2), f2)
+})
+
 test_that("quantile.tf_mv returns component-wise pointwise quantiles (oracle)", {
   set.seed(89)
   f <- tfd_mv(list(x = tf_rgp(5), y = tf_rgp(5)))

--- a/tests/testthat/test-mv-methods.R
+++ b/tests/testthat/test-mv-methods.R
@@ -227,6 +227,39 @@ test_that("trajectory plotting handles components on different / irregular grids
   expect_no_error(plot(irr))
 })
 
+test_that("quantile.tf_mv returns component-wise pointwise quantiles (oracle)", {
+  set.seed(89)
+  f <- tfd_mv(list(x = tf_rgp(5), y = tf_rgp(5)))
+  q <- suppressMessages(quantile(f))
+  expect_s3_class(q, "tf_mv")
+  expect_identical(tf_ncomp(q), 2L)
+  # one curve per probability level; default probs has length 5
+  expect_length(q, 5L)
+  # the established oracle: mv result == univariate result per component
+  expect_equal(q$x, suppressMessages(quantile(f$x)))
+  expect_equal(q$y, suppressMessages(quantile(f$y)))
+})
+
+test_that("quantile.tf_mv honours a probs vector of length > 1", {
+  set.seed(90)
+  f <- tfd_mv(list(x = tf_rgp(4), y = tf_rgp(4)))
+  probs <- c(0.1, 0.5, 0.9)
+  q <- suppressMessages(quantile(f, probs = probs))
+  expect_length(q, length(probs))
+  expect_equal(q$x, suppressMessages(quantile(f$x, probs = probs)))
+})
+
+test_that("quantile.tf_mv passes na.rm through per component", {
+  set.seed(91)
+  f <- tfd_mv(list(x = tf_rgp(5), y = tf_rgp(5)))
+  f$x[2] <- NA
+  # with na.rm = TRUE the NA curve is dropped from the pointwise quantiles
+  q <- suppressMessages(quantile(f, na.rm = TRUE))
+  expect_s3_class(q, "tf_mv")
+  expect_equal(q$x, suppressMessages(quantile(f$x, na.rm = TRUE)))
+  expect_equal(q$y, suppressMessages(quantile(f$y, na.rm = TRUE)))
+})
+
 test_that("print reports per-component grid / interpolator / basis info", {
   set.seed(9)
   # shared grid -> collapsed single info line


### PR DESCRIPTION
Part of #255's per-verb follow-up — the remaining verbs that aren't blocked on a design decision.

- **`quantile.tf_mv`**: component-wise pointwise quantiles, returning a `tf_mv` with one curve per requested probability. Oracle `quantile(fm, p)$x == quantile(fm$x, p)` holds (reviewer-verified incl. `probs` vectors and `na.rm = TRUE`). The "only pointwise quantiles available" inform fires once at the mv level instead of d times.
- **`points.tf_mv`**: mirrors `lines.tf_mv` exactly (`draw_trajectory()` gained a `mat_fun` parameter; `lines.tf_mv`'s behavior is byte-identical pre/post refactor — reviewer-verified). Trajectory mode requires `d == 2`, silently falling back to per-component overlay otherwise, matching lines' semantics.
- **`tf_invert.tf_mv`**: stub converted from "not (yet) defined" to a *permanent*, documented refusal — function inversion requires a monotone scalar function, which `f: R -> R^d` is not; the message points at per-component inversion (`tf_invert(f$x)`). Keeps the `tf_mv_method_unimplemented` class the walker test depends on.
- **Docs**: the `tf_mv_unimplemented` topic now notes that `summary`/`fivenum`/`rank`/`xtfrm`/`sort`/`tf_depth` await the multivariate-depth design (#273) and `tf_crosscov`/`tf_crosscor` await #274. Rd hand-patched (no `document()` churn); reviewer confirmed no #285-class `\link{}`-to-non-topic problems.
- **NEWS** entries for `quantile()` and `points()` in the established style.

Still stubbed pending design decisions: `summary`, `fivenum`, `rank`, `xtfrm`, `sort`, `tf_depth` (#273); `tf_crosscov`, `tf_crosscor` (#274).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9)_