### PR TITLE
Fix wave-fallout CI red: tf_scales test names + median.tf_mv pkgdown index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -42,6 +42,7 @@ reference:
   contents:
   - tfgroupgenerics
   - tfsummaries
+  - median.tf_mv
   - functionwise
   - tf_depth
   - tf_order

--- a/tests/testthat/test-register-mv-srvf.R
+++ b/tests/testthat/test-register-mv-srvf.R
@@ -147,7 +147,7 @@ test_that("tf_scales rescales aligned curves back to input arc lengths (#264)", 
   # curves: scaling each aligned curve by its factor recovers the input curve's
   # arc length. Equalization now happens inside the refinement loop (#264).
   expect_equal(
-    aligned_arclen * scales,
+    unname(aligned_arclen * scales),
     unname(input_arclen),
     tolerance = 1e-6
   )


### PR DESCRIPTION
**Fixes all current CI red on the mv branch** (test-coverage, the R CMD check matrix, and pkgdown — HEADs `a258811` / `26dc1d7` / `6e76a45`). Two small commits:

### 1. `test-register-mv-srvf.R:149` — names-only assertion mismatch

The #264 consistency test (added in #294) executed for the first time on CI — fdasrvf isn't installed in the dev container, so it always skipped locally — and failed on a **names-attribute mismatch only**:

```
Expected `aligned_arclen * scales` to equal `unname(input_arclen)`.
`names(actual)` is a character vector ('a', 'b', 'c')
`names(expected)` is absent
```

The arc-length values agree (the #264 fix itself is correct). One-line fix: unname both sides. Covers the test-coverage failures and the R CMD check matrix errors on all three merge-commit HEADs.

### 2. `_pkgdown.yml` — `median.tf_mv` missing from the reference index

The standalone `median.tf_mv` Rd topic added in #297 wasn't listed, and pkgdown aborts on unlisted topics:

```
! In _pkgdown.yml, 1 topic missing from index: "median.tf_mv".
```

Added next to `tfsummaries` in the summaries section. Covers the pkgdown failure.

After this merges, the only remaining red should be the known mlr3fda revdepcheck break (tracked separately; upstream issue drafted).

https://claude.ai/code/session_01M1QMfji5MpKJvzJYw5Kjb9