### PR TITLE
Return length-0 prototype for tfd(list())

### DIFF
--- a/R/tfd-class.R
+++ b/R/tfd-class.R
@@ -347,6 +347,11 @@ tfd.list <- function(
   ...
 ) {
   evaluator <- as_name(enexpr(evaluator))
+  if (vec_size(data) == 0) {
+    # empty input -> length-0 prototype, same as tfd(numeric(0)); skip the
+    # per-entry processing below, which would index into an empty arg list.
+    return(tfd(numeric(0), arg = arg, domain = domain, evaluator = !!evaluator))
+  }
   vectors <- map_lgl(data, \(x) is.null(x) || (is.numeric(x) & !is.array(x)))
   if (all(vectors)) {
     where_na <- map(data, is.na)

--- a/tests/testthat/test-empty-prototypes.R
+++ b/tests/testthat/test-empty-prototypes.R
@@ -24,6 +24,13 @@ test_that("vctrs combinations with empty tfd prototypes work", {
   expect_identical(vctrs::vec_c(tfb(), xb), xb)
 })
 
+test_that("tfd(list()) returns the length-0 prototype", {
+  x <- tfd(list())
+  expect_s3_class(x, "tfd")
+  expect_length(x, 0)
+  expect_identical(x, tfd(numeric(0)))
+})
+
 test_that("vctrs combinations with empty tf_mv prototypes work", {
   set.seed(4712)
   m <- tfd_mv(list(x = tf_rgp(3), y = tf_rgp(3)))


### PR DESCRIPTION
Fixes #296.

`tfd(list())` was falling through to the per-entry processing in `tfd.list()`, which ended up calling `assert_numeric(arg[[1]])` on an empty `arg` list and raising "subscript out of bounds". Now an empty `data` returns the same length-0 prototype that `tfd(numeric(0))` already produces, and the two are `identical()`.

Added a regression test in test-empty-prototypes.R.